### PR TITLE
Clarify LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-Copyright (c) 2013-2018 University of Cambridge
-
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

--- a/README.md
+++ b/README.md
@@ -215,3 +215,7 @@ The bundle contains translations for the form field and validation constraints.
 In cases where a language uses multiple terms for mobile phones, the generic language locale will use the term 'mobile', while country-specific locales will use the relevant term. So in English, for example, `en` uses 'mobile', `en_US` uses 'cell' and `en_SG` uses 'handphone'.
 
 If your language doesn't yet have translations, feel free to open a pull request to add them in!
+
+## License
+
+This bundle is released under the MIT License. See the bundled LICENSE file for details.


### PR DESCRIPTION
Fix #15 
I kept the MIT license & removed `Copyright (c) 2013-2018 University of Cambridge`.

If it's OK for you, I'll make another PR to remove all files headers.