### PR TITLE
Add note to services table to make clear IDs are removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you're using a container paremeter or alias defined by `misd/phone-number-bun
 
 The following services are available:
 
-| Service                                               | ID                                                 | libphonenumber version |
+| Service                                               | ID (Removed in 3.0)                                | libphonenumber version |
 | ----------------------------------------------------- | -------------------------------------------------- | ---------------------- |
 | `libphonenumber\PhoneNumberUtil`                      | `libphonenumber.phone_number_util`                 |                        |
 | `libphonenumber\geocoding\PhoneNumberOfflineGeocoder` | `libphonenumber.phone_number_offline_geocoder`     | >=5.8.8                |


### PR DESCRIPTION
Because either I read right past this change in the changelogs or it otherwise wasn't entirely clear to me, hopefully this change on the README makes it a little more clear the service IDs are removed in 3.0.