### PR TITLE
Support of null input value in denormalizer

### DIFF
--- a/src/Serializer/Normalizer/PhoneNumberNormalizer.php
+++ b/src/Serializer/Normalizer/PhoneNumberNormalizer.php
@@ -85,6 +85,10 @@ class PhoneNumberNormalizer implements NormalizerInterface, DenormalizerInterfac
      */
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (null === $data) {
+            return;
+        }
+
         try {
             return $this->phoneNumberUtil->parse($data, $this->region);
         } catch (NumberParseException $e) {

--- a/tests/Serializer/Normalizer/PhoneNumberNormalizerTest.php
+++ b/tests/Serializer/Normalizer/PhoneNumberNormalizerTest.php
@@ -17,6 +17,7 @@ use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
 use Misd\PhoneNumberBundle\Serializer\Normalizer\PhoneNumberNormalizer;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\Serializer;
 
@@ -72,6 +73,16 @@ class PhoneNumberNormalizerTest extends TestCase
         $normalizer = new PhoneNumberNormalizer($phoneNumberUtil->reveal());
 
         $this->assertSame($phoneNumber, $normalizer->denormalize('+33193166989', 'libphonenumber\PhoneNumber'));
+    }
+
+    public function testItDenormalizeNullToNull()
+    {
+        $phoneNumberUtil = $this->prophesize(PhoneNumberUtil::class);
+        $phoneNumberUtil->parse(Argument::cetera())->shouldNotBeCalled();
+
+        $normalizer = new PhoneNumberNormalizer($phoneNumberUtil->reveal());
+
+        $this->assertNull($normalizer->denormalize(null, 'libphonenumber\PhoneNumber'));
     }
 
     public function testInvalidDateThrowException()


### PR DESCRIPTION
`parse` method of the PhoneNumberUtil does not accept null values. This is a fix to return null in case null is received instead of failing.