### PR TITLE
use relace instead of conflict in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "symfony/twig-bundle": "Format phone numbers in Twig templates",
         "symfony/validator": "Add a validation constraint"
     },
-    "conflict": {
-        "misd/phone-number-bundle": "*"
+    "replace": {
+        "misd/phone-number-bundle": "self.version"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
A fork should use replace instead of conflict to show that it is a replacement for the original package:
https://getcomposer.org/doc/04-schema.md#replace