### PR TITLE
Bundle configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ sudo: false
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
+  - nightly
 
 cache:
     directories:
@@ -20,8 +21,10 @@ matrix:
           env: SYMFONY_VERSION=^4.3
         - php: 7.3
           env: SYMFONY_VERSION=^5.0
+        - php: 7.4
+          env: SYMFONY_VERSION=^5.0
     allow_failures:
-        - php: 7.4snapshot
+        - php: nightly
 
 before_install:
   - phpenv config-rm xdebug.ini || true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,5 +6,5 @@ parameters:
     inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:
         -
-            message: '#Call to an undefined static method Symfony\\Component\\Intl\\Intl::getRegionBundle().#'
+            message: '#Call to an undefined static method Symfony\\Component\\Intl\\Intl::getRegionBundle\(\).#'
             path: %currentWorkingDirectory%/src/Form/Type/PhoneNumberType.php

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony2 PhoneNumberBundle.
+ *
+ * (c) University of Cambridge
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Misd\PhoneNumberBundle\DependencyInjection;
+
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Form\FormTypeInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('misd_phone_number');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('misd_phone_number');
+        }
+        $rootNode
+            ->children()
+                ->scalarNode('twig')->defaultValue(class_exists(TwigBundle::class))->end()
+                ->scalarNode('form')->defaultValue(interface_exists(FormTypeInterface::class))->end()
+                ->scalarNode('serializer')->defaultValue(interface_exists(NormalizerInterface::class))->end()
+                ->scalarNode('validator')->defaultValue(interface_exists(ValidatorInterface::class))->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/MisdPhoneNumberExtension.php
+++ b/src/DependencyInjection/MisdPhoneNumberExtension.php
@@ -26,16 +26,22 @@ class MisdPhoneNumberExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
-        if (class_exists('Symfony\Bundle\TwigBundle\TwigBundle')) {
+        if ($config['twig']) {
             $loader->load('twig.xml');
         }
-        if (interface_exists('Symfony\Component\Form\FormTypeInterface')) {
+        if ($config['form']) {
             $loader->load('form.xml');
         }
-        if (interface_exists('Symfony\Component\Serializer\Normalizer\NormalizerInterface')) {
+        if ($config['serializer']) {
             $loader->load('serializer.xml');
+        }
+        if ($config['validator']) {
+            $loader->load('validator.xml');
         }
     }
 }

--- a/src/Resources/config/validator.xml
+++ b/src/Resources/config/validator.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumberValidator">
+            <tag name="validator.constraint_validator" />
+            <argument type="service" id="libphonenumber\PhoneNumberUtil" />
+        </service>
+    </services>
+
+</container>

--- a/src/Validator/Constraints/PhoneNumberValidator.php
+++ b/src/Validator/Constraints/PhoneNumberValidator.php
@@ -26,6 +26,16 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class PhoneNumberValidator extends ConstraintValidator
 {
     /**
+     * @var PhoneNumberUtil
+     */
+    private $phoneUtil;
+
+    public function __construct(PhoneNumberUtil $phoneUtil)
+    {
+        $this->phoneUtil = $phoneUtil;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint)
@@ -38,13 +48,11 @@ class PhoneNumberValidator extends ConstraintValidator
             throw new UnexpectedTypeException($value, 'string');
         }
 
-        $phoneUtil = PhoneNumberUtil::getInstance();
-
         if (false === $value instanceof PhoneNumberObject) {
             $value = (string) $value;
 
             try {
-                $phoneNumber = $phoneUtil->parse($value, $constraint->defaultRegion);
+                $phoneNumber = $this->phoneUtil->parse($value, $constraint->defaultRegion);
             } catch (NumberParseException $e) {
                 $this->addViolation($value, $constraint);
 
@@ -52,10 +60,10 @@ class PhoneNumberValidator extends ConstraintValidator
             }
         } else {
             $phoneNumber = $value;
-            $value = $phoneUtil->format($phoneNumber, PhoneNumberFormat::INTERNATIONAL);
+            $value = $this->phoneUtil->format($phoneNumber, PhoneNumberFormat::INTERNATIONAL);
         }
 
-        if (false === $phoneUtil->isValidNumber($phoneNumber)) {
+        if (false === $this->phoneUtil->isValidNumber($phoneNumber)) {
             $this->addViolation($value, $constraint);
 
             return;
@@ -102,7 +110,7 @@ class PhoneNumberValidator extends ConstraintValidator
         $validTypes = array_unique($validTypes);
 
         if (0 < \count($validTypes)) {
-            $type = $phoneUtil->getNumberType($phoneNumber);
+            $type = $this->phoneUtil->getNumberType($phoneNumber);
 
             if (!\in_array($type, $validTypes, true)) {
                 $this->addViolation($value, $constraint);

--- a/tests/DependencyInjection/MisdPhoneNumberExtensionTest.php
+++ b/tests/DependencyInjection/MisdPhoneNumberExtensionTest.php
@@ -52,5 +52,29 @@ class MisdPhoneNumberExtensionTest extends TestCase
         $services = $this->container->findTaggedServiceIds('form.type');
         $this->assertArrayHasKey('Misd\PhoneNumberBundle\Form\Type\PhoneNumberType', $services);
         $this->assertContains(['alias' => 'phone_number'], $services['Misd\PhoneNumberBundle\Form\Type\PhoneNumberType']);
+
+        $services = $this->container->findTaggedServiceIds('validator.constraint_validator');
+        $this->assertArrayHasKey('Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumberValidator', $services);
+    }
+
+    public function testDisabledServices()
+    {
+        $extension = new MisdPhoneNumberExtension();
+        $this->container = new ContainerBuilder();
+        $extension->load([
+            'misd_phone_number' => [
+                'twig' => false,
+                'form' => false,
+                'serializer' => false,
+                'validator' => false,
+            ],
+        ], $this->container);
+
+        $this->assertTrue($this->container->has('libphonenumber\PhoneNumberUtil'));
+
+        $this->assertFalse($this->container->has('Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberHelperExtension'));
+        $this->assertFalse($this->container->has('Misd\PhoneNumberBundle\Form\Type\PhoneNumberType'));
+        $this->assertFalse($this->container->has('Misd\PhoneNumberBundle\Serializer\Normalizer\PhoneNumberNormalizer'));
+        $this->assertFalse($this->container->has('Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumberValidator'));
     }
 }

--- a/tests/Validator/Constraints/PhoneNumberValidatorTest.php
+++ b/tests/Validator/Constraints/PhoneNumberValidatorTest.php
@@ -41,7 +41,7 @@ class PhoneNumberValidatorTest extends TestCase
     {
         $this->context = $this->prophesize(ExecutionContextInterface::class);
 
-        $this->validator = new PhoneNumberValidator();
+        $this->validator = new PhoneNumberValidator(PhoneNumberUtil::getInstance());
         $this->validator->initialize($this->context->reveal());
     }
 
@@ -140,6 +140,6 @@ class PhoneNumberValidatorTest extends TestCase
 
     protected function createValidator()
     {
-        return new PhoneNumberValidator();
+        return new PhoneNumberValidator(PhoneNumberUtil::getInstance());
     }
 }


### PR DESCRIPTION
Allow to disable integration with symfony components even they used in app. E.g. I want to validate phone numbers but don't want to serialize them so don't need redundant normalizers