### PR TITLE
Prevent denormalize PhoneNumber object twice

### DIFF
--- a/src/Serializer/Normalizer/PhoneNumberNormalizer.php
+++ b/src/Serializer/Normalizer/PhoneNumberNormalizer.php
@@ -89,6 +89,10 @@ class PhoneNumberNormalizer implements NormalizerInterface, DenormalizerInterfac
             return;
         }
 
+        if ($data instanceof PhoneNumber) {
+            return $data;
+        }
+
         try {
             return $this->phoneNumberUtil->parse($data, $this->region);
         } catch (NumberParseException $e) {

--- a/tests/Serializer/Normalizer/PhoneNumberNormalizerTest.php
+++ b/tests/Serializer/Normalizer/PhoneNumberNormalizerTest.php
@@ -59,6 +59,7 @@ class PhoneNumberNormalizerTest extends TestCase
         $normalizer = new PhoneNumberNormalizer($this->prophesize(PhoneNumberUtil::class)->reveal());
 
         $this->assertTrue($normalizer->supportsDenormalization('+33193166989', 'libphonenumber\PhoneNumber'));
+        $this->assertTrue($normalizer->supportsDenormalization(new PhoneNumber(), 'libphonenumber\PhoneNumber'));
         $this->assertFalse($normalizer->supportsDenormalization('+33193166989', 'stdClass'));
     }
 
@@ -73,6 +74,7 @@ class PhoneNumberNormalizerTest extends TestCase
         $normalizer = new PhoneNumberNormalizer($phoneNumberUtil->reveal());
 
         $this->assertSame($phoneNumber, $normalizer->denormalize('+33193166989', 'libphonenumber\PhoneNumber'));
+        $this->assertSame($phoneNumber, $normalizer->denormalize($phoneNumber, 'libphonenumber\PhoneNumber'));
     }
 
     public function testItDenormalizeNullToNull()


### PR DESCRIPTION
Or expect string in `supportsDenormalization` which one better?

```php
    public function supportsDenormalization($data, $type, $format = null)
    {
-        return 'libphonenumber\PhoneNumber' === $type;
+       return 'libphonenumber\PhoneNumber' === $type && is_string($data);
    }
```

Seems CI fail not related to this PR
