### PR TITLE
Make the form type example use the same property name as entity example issue #93

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 public function buildForm(FormBuilderInterface $builder, array $options)
 {
-    $builder->add('phone_number', PhoneNumberType::class, array('default_region' => 'GB', 'format' => PhoneNumberFormat::NATIONAL));
+    $builder->add('phoneNumber', PhoneNumberType::class, array('default_region' => 'GB', 'format' => PhoneNumberFormat::NATIONAL));
 }
 ```
 
@@ -153,7 +153,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 public function buildForm(FormBuilderInterface $builder, array $options)
 {
-    $builder->add('phone_number', PhoneNumberType::class, array('widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE, 'country_choices' => array('GB', 'JE', 'FR', 'US'), 'preferred_country_choices' => array('GB', 'JE')));
+    $builder->add('phoneNumber', PhoneNumberType::class, array('widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE, 'country_choices' => array('GB', 'JE', 'FR', 'US'), 'preferred_country_choices' => array('GB', 'JE')));
 }
 ```
 


### PR DESCRIPTION
fix #93 