### PR TITLE
Avoid php 8.1 deprecation.

### DIFF
--- a/src/Form/DataTransformer/PhoneNumberToArrayTransformer.php
+++ b/src/Form/DataTransformer/PhoneNumberToArrayTransformer.php
@@ -76,7 +76,7 @@ class PhoneNumberToArrayTransformer implements DataTransformerInterface
             throw new TransformationFailedException('Expected an array.');
         }
 
-        if ('' === trim($value['number'])) {
+        if ('' === trim($value['number'] ?? '')) {
             return null;
         }
 

--- a/src/Validator/Constraints/PhoneNumberValidator.php
+++ b/src/Validator/Constraints/PhoneNumberValidator.php
@@ -68,7 +68,7 @@ class PhoneNumberValidator extends ConstraintValidator
             return;
         }
 
-        if (!is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
+        if (!\is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 


### PR DESCRIPTION
HI @odolbeau 

I'm getting a deprecation
```
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/vincentlanglet/VenteUnique/v8/vendor/odolbeau/phone-number-bundle/src/Form/DataTransformer/PhoneNumberToArrayTransformer.php on line 79
```

This would solve the deprecation.