### PR TITLE
Adding return types everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Maintenance: added return types on methods, avoid deprecation trigger, make the bundle future-proof
+
 ### Fixed
 
 - Name of the catalan translation file is now accurate #116

--- a/src/DependencyInjection/Compiler/FormTwigTemplateCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FormTwigTemplateCompilerPass.php
@@ -58,7 +58,7 @@ class FormTwigTemplateCompilerPass implements CompilerPassInterface
             array_splice($parameter, ++$key, 0, [$this->phoneNumberLayout]);
         } else {
             // Put it in first position.
-            array_unshift($parameter, [$this->phoneNumberLayout]);
+            array_unshift($parameter, $this->phoneNumberLayout);
         }
 
         $container->setParameter('twig.form.resources', $parameter);

--- a/src/DependencyInjection/Compiler/FormTwigTemplateCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FormTwigTemplateCompilerPass.php
@@ -26,10 +26,8 @@ class FormTwigTemplateCompilerPass implements CompilerPassInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @return void
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasParameter('twig.form.resources')) {
             return;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -22,10 +22,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    /**
-     * @return TreeBuilder
-     */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('misd_phone_number');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/DependencyInjection/MisdPhoneNumberExtension.php
+++ b/src/DependencyInjection/MisdPhoneNumberExtension.php
@@ -23,10 +23,8 @@ class MisdPhoneNumberExtension extends Extension
 {
     /**
      * {@inheritdoc}
-     *
-     * @return void
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Doctrine/DBAL/Types/PhoneNumberType.php
+++ b/src/Doctrine/DBAL/Types/PhoneNumberType.php
@@ -31,30 +31,24 @@ class PhoneNumberType extends Type
 
     /**
      * {@inheritdoc}
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }
 
     /**
      * {@inheritdoc}
-     *
-     * @return mixed
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return $platform->getVarcharTypeDeclarationSQL(['length' => 35]);
     }
 
     /**
      * {@inheritdoc}
-     *
-     * @return mixed
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if (null === $value) {
             return null;
@@ -71,10 +65,8 @@ class PhoneNumberType extends Type
 
     /**
      * {@inheritdoc}
-     *
-     * @return mixed
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?PhoneNumber
     {
         if (null === $value || $value instanceof PhoneNumber) {
             return $value;
@@ -91,10 +83,8 @@ class PhoneNumberType extends Type
 
     /**
      * {@inheritdoc}
-     *
-     * @return bool
      */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }

--- a/src/Form/DataTransformer/PhoneNumberToArrayTransformer.php
+++ b/src/Form/DataTransformer/PhoneNumberToArrayTransformer.php
@@ -38,10 +38,8 @@ class PhoneNumberToArrayTransformer implements DataTransformerInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @return array
      */
-    public function transform($phoneNumber)
+    public function transform($phoneNumber): array
     {
         if (null === $phoneNumber) {
             return ['country' => '', 'number' => ''];
@@ -63,10 +61,8 @@ class PhoneNumberToArrayTransformer implements DataTransformerInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @return ?PhoneNumber
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): ?PhoneNumber
     {
         if (!$value) {
             return null;

--- a/src/Form/DataTransformer/PhoneNumberToStringTransformer.php
+++ b/src/Form/DataTransformer/PhoneNumberToStringTransformer.php
@@ -53,10 +53,8 @@ class PhoneNumberToStringTransformer implements DataTransformerInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @return string
      */
-    public function transform($phoneNumber)
+    public function transform($phoneNumber): string
     {
         if (null === $phoneNumber) {
             return '';
@@ -75,10 +73,8 @@ class PhoneNumberToStringTransformer implements DataTransformerInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @return ?PhoneNumber
      */
-    public function reverseTransform($string)
+    public function reverseTransform($string): ?PhoneNumber
     {
         if (!$string && '0' !== $string) {
             return null;

--- a/src/Form/Type/PhoneNumberType.php
+++ b/src/Form/Type/PhoneNumberType.php
@@ -36,7 +36,7 @@ class PhoneNumberType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if (self::WIDGET_COUNTRY_CHOICE === $options['widget']) {
             $util = PhoneNumberUtil::getInstance();
@@ -106,7 +106,7 @@ class PhoneNumberType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['type'] = 'tel';
         $view->vars['widget'] = $options['widget'];
@@ -115,7 +115,7 @@ class PhoneNumberType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'widget' => self::WIDGET_SINGLE_TEXT,
@@ -145,20 +145,16 @@ class PhoneNumberType extends AbstractType
 
     /**
      * {@inheritdoc}
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }
 
     /**
      * {@inheritdoc}
-     *
-     * @return string
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'phone_number';
     }

--- a/src/MisdPhoneNumberBundle.php
+++ b/src/MisdPhoneNumberBundle.php
@@ -23,7 +23,7 @@ class MisdPhoneNumberBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Serializer/Normalizer/PhoneNumberNormalizer.php
+++ b/src/Serializer/Normalizer/PhoneNumberNormalizer.php
@@ -64,10 +64,8 @@ class PhoneNumberNormalizer implements NormalizerInterface, DenormalizerInterfac
      * {@inheritdoc}
      *
      * @throws InvalidArgumentException
-     *
-     * @return array|string|int|float|bool|\ArrayObject|null
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): string
     {
         return $this->phoneNumberUtil->format($object, $this->format);
     }
@@ -84,13 +82,11 @@ class PhoneNumberNormalizer implements NormalizerInterface, DenormalizerInterfac
      * {@inheritdoc}
      *
      * @throws UnexpectedValueException
-     *
-     * @return mixed
      */
-    public function denormalize($data, $class, $format = null, array $context = [])
+    public function denormalize($data, $class, $format = null, array $context = []): ?PhoneNumber
     {
         if (null === $data) {
-            return;
+            return null;
         }
 
         try {
@@ -102,10 +98,8 @@ class PhoneNumberNormalizer implements NormalizerInterface, DenormalizerInterfac
 
     /**
      * {@inheritdoc}
-     *
-     * @return bool
      */
-    public function supportsDenormalization($data, $type, $format = null, array $context = [])
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
         return 'libphonenumber\PhoneNumber' === $type && \is_string($data);
     }

--- a/src/Templating/Helper/PhoneNumberHelper.php
+++ b/src/Templating/Helper/PhoneNumberHelper.php
@@ -49,7 +49,7 @@ class PhoneNumberHelper
      *
      * @throws InvalidArgumentException if an argument is invalid
      */
-    public function format(PhoneNumber $phoneNumber, $format = PhoneNumberFormat::INTERNATIONAL)
+    public function format(PhoneNumber $phoneNumber, $format = PhoneNumberFormat::INTERNATIONAL): string
     {
         if (true === \is_string($format)) {
             $constant = '\libphonenumber\PhoneNumberFormat::'.$format;
@@ -69,10 +69,8 @@ class PhoneNumberHelper
      *
      * @param PhoneNumber $phoneNumber phone number
      * @param string|null $regionCode  The ISO 3166-1 alpha-2 country code
-     *
-     * @return string
      */
-    public function formatOutOfCountryCallingNumber(PhoneNumber $phoneNumber, $regionCode)
+    public function formatOutOfCountryCallingNumber(PhoneNumber $phoneNumber, $regionCode): string
     {
         return $this->phoneNumberUtil->formatOutOfCountryCallingNumber($phoneNumber, $regionCode);
     }
@@ -81,11 +79,9 @@ class PhoneNumberHelper
      * @param PhoneNumber $phoneNumber phone number
      * @param int|string  $type        phoneNumberType, or PhoneNumberType constant name
      *
-     * @return bool
-     *
      * @throws InvalidArgumentException if type argument is invalid
      */
-    public function isType(PhoneNumber $phoneNumber, $type = PhoneNumberType::UNKNOWN)
+    public function isType(PhoneNumber $phoneNumber, $type = PhoneNumberType::UNKNOWN): bool
     {
         if (true === \is_string($type)) {
             $constant = '\libphonenumber\PhoneNumberType::'.$type;
@@ -97,6 +93,6 @@ class PhoneNumberHelper
             $type = \constant('\libphonenumber\PhoneNumberType::'.$type);
         }
 
-        return $this->phoneNumberUtil->getNumberType($phoneNumber) === $type ? true : false;
+        return $this->phoneNumberUtil->getNumberType($phoneNumber) === $type;
     }
 }

--- a/src/Twig/Extension/PhoneNumberHelperExtension.php
+++ b/src/Twig/Extension/PhoneNumberHelperExtension.php
@@ -41,10 +41,8 @@ class PhoneNumberHelperExtension extends AbstractExtension
 
     /**
      * {@inheritdoc}
-     *
-     * @return array
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             // Deprecated in favor of the phone_number_format filter
@@ -55,10 +53,8 @@ class PhoneNumberHelperExtension extends AbstractExtension
 
     /**
      * {@inheritdoc}
-     *
-     * @return array
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('phone_number_format', [$this->helper, 'format']),
@@ -68,10 +64,8 @@ class PhoneNumberHelperExtension extends AbstractExtension
 
     /**
      * {@inheritdoc}
-     *
-     * @return array
      */
-    public function getTests()
+    public function getTests(): array
     {
         return [
             new TwigTest('phone_number_of_type', [$this->helper, 'isType']),

--- a/src/Validator/Constraints/PhoneNumberValidator.php
+++ b/src/Validator/Constraints/PhoneNumberValidator.php
@@ -59,10 +59,8 @@ class PhoneNumberValidator extends ConstraintValidator
 
     /**
      * {@inheritdoc}
-     *
-     * @return void
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (null === $value || '' === $value) {
             return;
@@ -138,8 +136,6 @@ class PhoneNumberValidator extends ConstraintValidator
 
             if (!\in_array($type, $validTypes, true)) {
                 $this->addViolation($value, $constraint);
-
-                return;
             }
         }
     }
@@ -185,10 +181,8 @@ class PhoneNumberValidator extends ConstraintValidator
      *
      * @param mixed      $value      the value that should be validated
      * @param Constraint $constraint the constraint for the validation
-     *
-     * @return void
      */
-    private function addViolation($value, Constraint $constraint)
+    private function addViolation($value, Constraint $constraint): void
     {
         $this->context->buildViolation($constraint->getMessage())
             ->setParameter('{{ types }}', implode(', ', $constraint->getTypeNames()))

--- a/tests/DependencyInjection/Compiler/FormTwigTemplateCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/FormTwigTemplateCompilerPassTest.php
@@ -6,7 +6,7 @@ use Misd\PhoneNumberBundle\DependencyInjection\Compiler\FormTwigTemplateCompiler
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class FormTwigTemplateCompilerPassTest extends TestCase
+final class FormTwigTemplateCompilerPassTest extends TestCase
 {
     public function testItDoesNothingWhenWithIsNotEnabled(): void
     {
@@ -27,7 +27,7 @@ class FormTwigTemplateCompilerPassTest extends TestCase
 
         $subject->process($container);
 
-        $this->assertEquals(
+        $this->assertSame(
             $inputParameter,
             $container->getParameter('twig.form.resources')
         );
@@ -48,7 +48,7 @@ class FormTwigTemplateCompilerPassTest extends TestCase
         $this->assertTrue(\in_array($phoneTemplate, $container->getParameter('twig.form.resources'), true));
     }
 
-    public function themesProvider()
+    public function themesProvider(): iterable
     {
         yield 'Bootstrap 5 horizontal' => [
             'bootstrap_5_horizontal_layout.html.twig',

--- a/tests/DependencyInjection/Compiler/FormTwigTemplateCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/FormTwigTemplateCompilerPassTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Misd\PhoneNumberBundle\Tests\DependencyInjection\Compiler;
+
+use Misd\PhoneNumberBundle\DependencyInjection\Compiler\FormTwigTemplateCompilerPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class FormTwigTemplateCompilerPassTest extends TestCase
+{
+    public function testItDoesNothingWhenWithIsNotEnabled(): void
+    {
+        $subject = new FormTwigTemplateCompilerPass();
+        $container = new ContainerBuilder();
+
+        $subject->process($container);
+
+        $this->assertFalse($container->hasParameter('twig.form.resources'));
+    }
+
+    public function testItDoesNothingIfThePhoneNumberTwigIsAlreadyConfigured()
+    {
+        $subject = new FormTwigTemplateCompilerPass();
+        $container = new ContainerBuilder();
+        $inputParameter = ['@MisdPhoneNumber/Form/phone_number.html.twig'];
+        $container->setParameter('twig.form.resources', $inputParameter);
+
+        $subject->process($container);
+
+        $this->assertEquals(
+            $inputParameter,
+            $container->getParameter('twig.form.resources')
+        );
+    }
+
+    /**
+     * @dataProvider themesProvider
+     */
+    public function testItAddsPhoneTemplatesAccordingToSymfonyTemplates($sfTemplate, $phoneTemplate)
+    {
+        $subject = new FormTwigTemplateCompilerPass();
+        $container = new ContainerBuilder();
+        $inputParameter = [$sfTemplate];
+        $container->setParameter('twig.form.resources', $inputParameter);
+
+        $subject->process($container);
+
+        $this->assertTrue(\in_array($phoneTemplate, $container->getParameter('twig.form.resources'), true));
+    }
+
+    public function themesProvider()
+    {
+        yield 'Bootstrap 5 horizontal' => [
+            'bootstrap_5_horizontal_layout.html.twig',
+            '@MisdPhoneNumber/Form/phone_number_bootstrap_5.html.twig',
+        ];
+        yield 'Bootstrap 5 vertical' => [
+            'bootstrap_5_layout.html.twig',
+            '@MisdPhoneNumber/Form/phone_number_bootstrap_5.html.twig',
+        ];
+        yield 'Bootstrap 4 horizontal' => [
+            'bootstrap_4_horizontal_layout.html.twig',
+            '@MisdPhoneNumber/Form/phone_number_bootstrap_4.html.twig',
+        ];
+        yield 'Bootstrap 4 vertical' => [
+            'bootstrap_4_layout.html.twig',
+            '@MisdPhoneNumber/Form/phone_number_bootstrap_4.html.twig',
+        ];
+        yield 'Bootstrap 3 horizontal' => [
+            'bootstrap_3_horizontal_layout.html.twig',
+            '@MisdPhoneNumber/Form/phone_number_bootstrap.html.twig',
+        ];
+        yield 'Bootstrap 3 vertical' => [
+            'bootstrap_3_layout.html.twig',
+            '@MisdPhoneNumber/Form/phone_number_bootstrap.html.twig',
+        ];
+        yield 'It adds phone number when using standard symfony form layout' => [
+            'form_div_layout.html.twig',
+            '@MisdPhoneNumber/Form/phone_number.html.twig',
+        ];
+        yield 'Test it enables phone number template anyway' => [
+            'i_have_yolo_layout.html.twig',
+            '@MisdPhoneNumber/Form/phone_number.html.twig',
+        ];
+    }
+}

--- a/tests/Form/Type/PhoneNumberTypeTest.php
+++ b/tests/Form/Type/PhoneNumberTypeTest.php
@@ -122,7 +122,11 @@ class PhoneNumberTypeTest extends TestCase
     {
         IntlTestHelper::requireIntl($this);
 
-        $form = $this->factory->create(PhoneNumberType::class, null, ['widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE, 'country_choices' => $choices]);
+        $form = $this->factory->create(
+            PhoneNumberType::class,
+            null,
+            ['widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE, 'country_choices' => $choices]
+        );
 
         $view = $form->createView();
         $choices = $view['country']->vars['choices'];

--- a/tests/Templating/Helper/PhoneNumberHelperTest.php
+++ b/tests/Templating/Helper/PhoneNumberHelperTest.php
@@ -41,7 +41,10 @@ class PhoneNumberHelperTest extends TestCase
     public function testProcess($format, $expectedFormat)
     {
         $phoneNumber = $this->prophesize(PhoneNumber::class);
-        $this->phoneNumberUtil->format($phoneNumber->reveal(), $expectedFormat)->shouldBeCalledTimes(1);
+        $this->phoneNumberUtil
+            ->format($phoneNumber->reveal(), $expectedFormat)
+            ->shouldBeCalledTimes(1)
+            ->willReturn('+33600000000');
 
         $this->helper->format($phoneNumber->reveal(), $format);
     }


### PR DESCRIPTION
This PR is about adding return types everywhere to get definitely rid of deprecation notice.

Since the code is battle-tested tests should highlight any place when it's wrong. The only class that was not tested is now tested!

This stands as a replacement for #109 .

----------------------------

Since we're using PHP 7.4 as the minimum requirement, there's no problem with this PR. However, the `normalize()` method of the normalizer has union return types. Luckily, we do not need it, so I added the return type string anyway.

Regarding the `declare(strict_types=1)`, I think we should open an issue for version 4.x of the bundle, WDYT?
