### PR TITLE
fix doc about phone number type validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,12 @@ By default any valid phone number will be accepted. You can restrict the type th
 (Note that libphonenumber cannot always distinguish between mobile and fixed-line numbers (eg in the USA), in which case it will be accepted.)
 
 ```php
-#[AssertPhoneNumber(type: [PhoneNumber::MOBILE])]
+use Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumber as AssertPhoneNumber;
+
+#[AssertPhoneNumber(type: [AssertPhoneNumber::MOBILE])]
 private $mobilePhoneNumber;
 
-#[AssertPhoneNumber(type: [PhoneNumber::FIXED_LINE, PhoneNumber::VOIP])]
+#[AssertPhoneNumber(type: [AssertPhoneNumber::FIXED_LINE, AssertPhoneNumber::VOIP])]
 private $fixedOrVoipPhoneNumber;
 ```
 


### PR DESCRIPTION
Tiny fix about the phone number type validation in doc. Types constants were called from the unaliased class `PhoneNumber`, it can be confusing. I thought myself constants come from `libphonenumber\PhoneNumber` at first.