### PR TITLE
Fix PhoneNumber constraint default message

### DIFF
--- a/src/Validator/Constraints/PhoneNumber.php
+++ b/src/Validator/Constraints/PhoneNumber.php
@@ -112,7 +112,7 @@ class PhoneNumber extends Constraint
             return "This value is not a valid $typeName.";
         }
 
-        return 'This value is not a valid number.';
+        return 'This value is not a valid phone number.';
     }
 
     public function getTypeNames(): array


### PR DESCRIPTION
If using validation by [@Attribute](https://github.com/odolbeau/phone-number-bundle/blob/master/src/Validator/Constraints/PhoneNumber.php), when it fails, the default message when there is more than one type is:

https://github.com/odolbeau/phone-number-bundle/blob/40e330c21d24903fac53aca5acb4b2ebce7a38a3/src/Validator/Constraints/PhoneNumber.php#L115

Which does not have a translated message.
As I see, the default message should be "[This value is not a valid phone number.](https://github.com/odolbeau/phone-number-bundle/blob/40e330c21d24903fac53aca5acb4b2ebce7a38a3/src/Resources/translations/validators.en.xlf#L5)".