### PR TITLE
:adhesive_bandage: Fix deprecation notice in the constraint

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,3 +4,8 @@ parameters:
       - src
       - tests
     inferPrivatePropertyTypeFromConstructor: true
+    ignoreErrors:
+        -
+            message: "#^Attribute class Symfony\\\\Component\\\\Validator\\\\Attribute\\\\HasNamedArguments does not exist\\.$#"
+            count: 1
+            path: src/Validator/Constraints/PhoneNumber.php

--- a/src/Validator/Constraints/PhoneNumber.php
+++ b/src/Validator/Constraints/PhoneNumber.php
@@ -12,6 +12,7 @@
 namespace Misd\PhoneNumberBundle\Validator\Constraints;
 
 use Misd\PhoneNumberBundle\Exception\InvalidArgumentException;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
@@ -60,6 +61,7 @@ class PhoneNumber extends Constraint
      *                                  or options (an associative array)
      * @param string|array|null $type
      */
+    #[HasNamedArguments]
     public function __construct($format = null, $type = null, string $defaultRegion = null, string $regionPath = null, string $message = null, array $groups = null, $payload = null, array $options = [])
     {
         if (\is_array($format)) {


### PR DESCRIPTION
As @garak highlighted here: https://github.com/odolbeau/phone-number-bundle/issues/113#issuecomment-1382707339 the work in https://github.com/odolbeau/phone-number-bundle/pull/119 was not complete.

Since Symfony 6.1 we need to add a new attribute HasNamedArguments which is required for constraints using constructors: https://symfony.com/doc/current/validation/custom_constraint.html#creating-the-constraint-class