### PR TITLE
feat: drop support of symfony < 5.4, 

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: PHPStan
-        uses: docker://jakzal/phpqa:php8.0
+        uses: docker://jakzal/phpqa:php8.2
         with:
           args: phpstan analyze --no-progress
 
@@ -17,6 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: PHP-CS-Fixer
-        uses: docker://jakzal/phpqa:php8.0
+        uses: docker://jakzal/phpqa:php8.2
         with:
           args: php-cs-fixer fix --config=.php_cs.dist.php --dry-run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,18 +14,18 @@ jobs:
       matrix:
         include:
           - php: '7.4'
-            symfony-require: 4.4.*
+            symfony-require: 5.4.*
           - php: '8.0'
-            symfony-require: 5.3.*
+            symfony-require: 5.4.*
           - php: '8.0'
             symfony-require: 6.0.*
-            stability: dev
           - php: '8.1'
+          - php: '8.2'
       fail-fast: false
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove support of symfony < 5.4 (5.4 is new LTS)
+
 ## [3.9.1] - 2023-01-16
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -14,18 +14,18 @@
     "require": {
         "php": ">=7.4",
         "giggsey/libphonenumber-for-php": "^8.0",
-        "symfony/framework-bundle": "^4.4|^5.3|^6.0",
-        "symfony/intl": "^4.4|^5.3|^6.0"
+        "symfony/framework-bundle": "^5.4|^6.0",
+        "symfony/intl": "^5.4|^6.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12|^2.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
-        "symfony/form": "^4.4|^5.3|^6.0",
-        "symfony/property-access": "^4.4|^5.3|^6.0",
-        "symfony/serializer": "^4.4|^5.3|^6.0.1",
-        "symfony/twig-bundle": "^4.4|^5.3|^6.0",
-        "symfony/validator": "^4.4|^5.3|^6.0"
+        "symfony/form": "^5.4|^6.0",
+        "symfony/property-access": "^5.4|^6.0",
+        "symfony/serializer": "^5.4|^6.0.1",
+        "symfony/twig-bundle": "^5.4|^6.0",
+        "symfony/validator": "^5.4|^6.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "Add a DBAL mapping type",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
 
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
-    <testsuites>
-        <testsuite name="MisdPhoneNumberBundle Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+
+  <testsuites>
+    <testsuite name="MisdPhoneNumberBundle Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+
 </phpunit>


### PR DESCRIPTION
migrate phpunit config-format for v9.

Symfony 4.4 is no longer LTS https://symfony.com/releases/4.4 and should be droped in my eyes.

Any thoughts on dropping support of php < 8.0?