### PR TITLE
[Twig] allow to use string phone numbers in templates filters

### DIFF
--- a/src/Templating/Helper/PhoneNumberHelper.php
+++ b/src/Templating/Helper/PhoneNumberHelper.php
@@ -44,7 +44,7 @@ class PhoneNumberHelper
      * Format a phone number.
      *
      * @param PhoneNumber|string $phoneNumber phone number
-     * @param int|string  $format      format, or format constant name
+     * @param int|string         $format      format, or format constant name
      *
      * @return string formatted phone number
      *
@@ -71,7 +71,7 @@ class PhoneNumberHelper
      * Formats this phone number for out-of-country dialing purposes.
      *
      * @param PhoneNumber|string $phoneNumber phone number
-     * @param string|null $regionCode  The ISO 3166-1 alpha-2 country code
+     * @param string|null        $regionCode  The ISO 3166-1 alpha-2 country code
      */
     public function formatOutOfCountryCallingNumber($phoneNumber, $regionCode): string
     {
@@ -82,7 +82,7 @@ class PhoneNumberHelper
 
     /**
      * @param PhoneNumber|string $phoneNumber phone number
-     * @param int|string  $type        phoneNumberType, or PhoneNumberType constant name
+     * @param int|string         $type        phoneNumberType, or PhoneNumberType constant name
      *
      * @throws InvalidArgumentException if type argument is invalid
      */
@@ -105,20 +105,19 @@ class PhoneNumberHelper
 
     /**
      * @param PhoneNumber|string $phoneNumber
+     *
      * @return PhoneNumber|void
+     *
      * @throws \libphonenumber\NumberParseException
      */
     private function getPhoneNumber($phoneNumber)
     {
-        if (is_string($phoneNumber)) {
+        if (\is_string($phoneNumber)) {
             $phoneNumber = $this->phoneNumberUtil->parse($phoneNumber);
         }
 
         if (!$phoneNumber instanceof PhoneNumber) {
-            throw new NumberParseException(
-                NumberParseException::NOT_A_NUMBER,
-                'The phone number supplied is not PhoneNumber or string.'
-            );
+            throw new InvalidArgumentException('The phone number supplied is not PhoneNumber or string.');
         }
 
         return $phoneNumber;

--- a/src/Templating/Helper/PhoneNumberHelper.php
+++ b/src/Templating/Helper/PhoneNumberHelper.php
@@ -11,6 +11,7 @@
 
 namespace Misd\PhoneNumberBundle\Templating\Helper;
 
+use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumber;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberType;
@@ -42,15 +43,17 @@ class PhoneNumberHelper
     /**
      * Format a phone number.
      *
-     * @param PhoneNumber $phoneNumber phone number
+     * @param PhoneNumber|string $phoneNumber phone number
      * @param int|string  $format      format, or format constant name
      *
      * @return string formatted phone number
      *
      * @throws InvalidArgumentException if an argument is invalid
      */
-    public function format(PhoneNumber $phoneNumber, $format = PhoneNumberFormat::INTERNATIONAL): string
+    public function format($phoneNumber, $format = PhoneNumberFormat::INTERNATIONAL): string
     {
+        $phoneNumber = $this->getPhoneNumber($phoneNumber);
+
         if (true === \is_string($format)) {
             $constant = '\libphonenumber\PhoneNumberFormat::'.$format;
 
@@ -67,22 +70,26 @@ class PhoneNumberHelper
     /**
      * Formats this phone number for out-of-country dialing purposes.
      *
-     * @param PhoneNumber $phoneNumber phone number
+     * @param PhoneNumber|string $phoneNumber phone number
      * @param string|null $regionCode  The ISO 3166-1 alpha-2 country code
      */
-    public function formatOutOfCountryCallingNumber(PhoneNumber $phoneNumber, $regionCode): string
+    public function formatOutOfCountryCallingNumber($phoneNumber, $regionCode): string
     {
+        $phoneNumber = $this->getPhoneNumber($phoneNumber);
+
         return $this->phoneNumberUtil->formatOutOfCountryCallingNumber($phoneNumber, $regionCode);
     }
 
     /**
-     * @param PhoneNumber $phoneNumber phone number
+     * @param PhoneNumber|string $phoneNumber phone number
      * @param int|string  $type        phoneNumberType, or PhoneNumberType constant name
      *
      * @throws InvalidArgumentException if type argument is invalid
      */
-    public function isType(PhoneNumber $phoneNumber, $type = PhoneNumberType::UNKNOWN): bool
+    public function isType($phoneNumber, $type = PhoneNumberType::UNKNOWN): bool
     {
+        $phoneNumber = $this->getPhoneNumber($phoneNumber);
+
         if (true === \is_string($type)) {
             $constant = '\libphonenumber\PhoneNumberType::'.$type;
 
@@ -94,5 +101,26 @@ class PhoneNumberHelper
         }
 
         return $this->phoneNumberUtil->getNumberType($phoneNumber) === $type;
+    }
+
+    /**
+     * @param PhoneNumber|string $phoneNumber
+     * @return PhoneNumber|void
+     * @throws \libphonenumber\NumberParseException
+     */
+    private function getPhoneNumber($phoneNumber)
+    {
+        if (is_string($phoneNumber)) {
+            $phoneNumber = $this->phoneNumberUtil->parse($phoneNumber);
+        }
+
+        if (!$phoneNumber instanceof PhoneNumber) {
+            throw new NumberParseException(
+                NumberParseException::NOT_A_NUMBER,
+                'The phone number supplied is not PhoneNumber or string.'
+            );
+        }
+
+        return $phoneNumber;
     }
 }

--- a/src/Templating/Helper/PhoneNumberHelper.php
+++ b/src/Templating/Helper/PhoneNumberHelper.php
@@ -11,7 +11,6 @@
 
 namespace Misd\PhoneNumberBundle\Templating\Helper;
 
-use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumber;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberType;

--- a/tests/Templating/Helper/PhoneNumberHelperTest.php
+++ b/tests/Templating/Helper/PhoneNumberHelperTest.php
@@ -87,15 +87,14 @@ class PhoneNumberHelperTest extends TestCase
         $phoneNumberUtil = PhoneNumberUtil::getInstance();
         $helper = new PhoneNumberHelper($phoneNumberUtil);
         $result = $helper->format('+37122222222');
-        $this->assertEquals( '+371 22 222 222', $result);
+        $this->assertEquals('+371 22 222 222', $result);
     }
 
     public function testFormatAcceptNotAllowValue()
     {
         $phoneNumberUtil = PhoneNumberUtil::getInstance();
         $helper = new PhoneNumberHelper($phoneNumberUtil);
-        $this->expectException(NumberParseException::class);
-        $this->expectExceptionCode(\libphonenumber\NumberParseException::NOT_A_NUMBER);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The phone number supplied is not PhoneNumber or string.');
         $helper->format(0037122222222);
     }
@@ -105,7 +104,7 @@ class PhoneNumberHelperTest extends TestCase
         $phoneNumberUtil = PhoneNumberUtil::getInstance();
         $helper = new PhoneNumberHelper($phoneNumberUtil);
         $result = $helper->formatOutOfCountryCallingNumber('+37122222222', 'LV');
-        $this->assertEquals( '+371 22 222 222', $result);
+        $this->assertEquals('+371 22 222 222', $result);
     }
 
     /**

--- a/tests/Templating/Helper/PhoneNumberHelperTest.php
+++ b/tests/Templating/Helper/PhoneNumberHelperTest.php
@@ -11,6 +11,7 @@
 
 namespace Misd\PhoneNumberBundle\Tests\Templating\Helper;
 
+use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumber;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
@@ -79,6 +80,32 @@ class PhoneNumberHelperTest extends TestCase
         $phoneNumber = $phoneNumberUtil->parse($phoneNumber, $defaultRegion);
 
         $this->assertSame($expectedResult, $helper->formatOutOfCountryCallingNumber($phoneNumber, $regionCode));
+    }
+
+    public function testFormatAcceptString()
+    {
+        $phoneNumberUtil = PhoneNumberUtil::getInstance();
+        $helper = new PhoneNumberHelper($phoneNumberUtil);
+        $result = $helper->format('+37122222222');
+        $this->assertEquals( '+371 22 222 222', $result);
+    }
+
+    public function testFormatAcceptNotAllowValue()
+    {
+        $phoneNumberUtil = PhoneNumberUtil::getInstance();
+        $helper = new PhoneNumberHelper($phoneNumberUtil);
+        $this->expectException(NumberParseException::class);
+        $this->expectExceptionCode(\libphonenumber\NumberParseException::NOT_A_NUMBER);
+        $this->expectExceptionMessage('The phone number supplied is not PhoneNumber or string.');
+        $helper->format(0037122222222);
+    }
+
+    public function formatOutOfCountryCallingNumberAcceptString()
+    {
+        $phoneNumberUtil = PhoneNumberUtil::getInstance();
+        $helper = new PhoneNumberHelper($phoneNumberUtil);
+        $result = $helper->formatOutOfCountryCallingNumber('+37122222222', 'LV');
+        $this->assertEquals( '+371 22 222 222', $result);
     }
 
     /**

--- a/tests/Templating/Helper/PhoneNumberHelperTest.php
+++ b/tests/Templating/Helper/PhoneNumberHelperTest.php
@@ -11,7 +11,6 @@
 
 namespace Misd\PhoneNumberBundle\Tests\Templating\Helper;
 
-use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumber;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;


### PR DESCRIPTION
When working with any templating enging in most cases we work with string and objects.

This PR allows using string for Twig filters.