### PR TITLE
feat: Configurable Doctrine SQL Column Length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The default value for the `PhoneNumberType` form type option `country_display_emoji_flag` will change from `false` to `true` on the next major release
+- The Doctrine column type length is configurable. Any existing `length` configuration (not taken into account before this release) will now be taken into account.
 
 ## [3.9.2] - 2023-06-29
 

--- a/src/Doctrine/DBAL/Types/PhoneNumberType.php
+++ b/src/Doctrine/DBAL/Types/PhoneNumberType.php
@@ -36,7 +36,7 @@ class PhoneNumberType extends Type
 
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
-        return $platform->getVarcharTypeDeclarationSQL(['length' => 35]);
+        return $platform->getVarcharTypeDeclarationSQL(['length' => $fieldDeclaration['length'] ?? 35]);
     }
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string


### PR DESCRIPTION
Using the form type supplied, the number is automatically converted to the [E164 format](https://en.wikipedia.org/wiki/E.164). The E164 format has a maximum of 15 digits (without the "+"), so the length must be configurable, as the doctrine format is 35 characters long and hard-coded.

With my PR, it's now possible to configure the length of the column. For instance:
```php
#[ORM\Column(type: PhoneNumberType::NAME, length: 16)]
private ?PhoneNumber $phoneNumber = null;
```

#156 