### PR TITLE
Bump minimum requirements & supports SF 7.0

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: PHPStan
-        uses: docker://jakzal/phpqa:php8.0
+        uses: docker://jakzal/phpqa:php8.2
         with:
           args: phpstan analyze --no-progress
 
@@ -17,6 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: PHP-CS-Fixer
-        uses: docker://jakzal/phpqa:php8.0
+        uses: docker://jakzal/phpqa:php8.2
         with:
           args: php-cs-fixer fix --config=.php_cs.dist.php --dry-run --diff

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,6 @@
 name: PHPUnit
 
 on:
-  push:
   pull_request:
 
 jobs:
@@ -11,17 +10,25 @@ jobs:
     runs-on: Ubuntu-20.04
 
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - php: '7.4'
-            symfony-require: 4.4.*
-          - php: '8.0'
-            symfony-require: 5.3.*
-          - php: '8.0'
-            symfony-require: 6.0.*
+          # Lowest Deps
+          - php: 8.1
+            symfony-require: 5.4.*
+          # LTS with latest (supported) stable PHP
+          - php: 8.2
+            symfony-require: 5.4.*
+          # Active release
+          - php: latest
+            symfony-require: 6.3.*
+          - php: latest
+            symfony-require: 7.0.*
+          # Development release
+          - php: nightly
+            symfony-require: 7.0.*@dev
             stability: dev
-          - php: '8.1'
-      fail-fast: false
+            continue-on-error: true
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Remove support of Symfony 4.x, 5.3 & < 6.3
+- Add support for Symfony 7.0
 - The default value for the `PhoneNumberType` form type option `country_display_emoji_flag` will change from `false` to `true` on the next major release
 - The Doctrine column type length is configurable. Any existing `length` configuration (not taken into account before this release) will now be taken into account.
 

--- a/composer.json
+++ b/composer.json
@@ -12,22 +12,22 @@
         "sort-packages": true
     },
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "giggsey/libphonenumber-for-php": "^8.0",
-        "symfony/framework-bundle": "^4.4|^5.3|^6.0",
-        "symfony/intl": "^4.4|^5.3|^6.0",
+        "symfony/framework-bundle": "^5.4|^6.3|^7.0",
+        "symfony/intl": "^5.4|^6.3|^7.0",
         "symfony/polyfill-mbstring": "^1.28"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12|^2.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
-        "symfony/form": "^4.4|^5.3|^6.0",
-        "symfony/phpunit-bridge": "^6.2",
-        "symfony/property-access": "^4.4|^5.3|^6.0",
-        "symfony/serializer": "^4.4|^5.3|^6.0.1",
-        "symfony/twig-bundle": "^4.4|^5.3|^6.0",
-        "symfony/validator": "^4.4|^5.3|^6.0"
+        "symfony/form": "^5.4|^6.3|^7.0",
+        "symfony/phpunit-bridge": "^7.0",
+        "symfony/property-access": "^5.4|^6.3|^7.0",
+        "symfony/serializer": "^5.4|^6.3|^7.0",
+        "symfony/twig-bundle": "^5.4|^6.3|^7.0",
+        "symfony/validator": "^5.4|^6.3|^7.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "Add a DBAL mapping type",
@@ -52,10 +52,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.6.x-dev"
+            "dev-master": "3.9.x-dev"
         }
-    },
-    "conflict": {
-        "symfony/serializer": "6.0.0"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,8 +4,3 @@ parameters:
       - src
       - tests
     inferPrivatePropertyTypeFromConstructor: true
-    ignoreErrors:
-        -
-            message: "#^Attribute class Symfony\\\\Component\\\\Validator\\\\Attribute\\\\HasNamedArguments does not exist\\.$#"
-            count: 1
-            path: src/Validator/Constraints/PhoneNumber.php

--- a/src/Validator/Constraints/PhoneNumber.php
+++ b/src/Validator/Constraints/PhoneNumber.php
@@ -19,7 +19,6 @@ use Symfony\Component\Validator\Constraint;
  * Phone number constraint.
  *
  * @Annotation
- *
  * @NamedArgumentConstructor
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY)]

--- a/tests/Validator/Constraints/PhoneNumberTest.php
+++ b/tests/Validator/Constraints/PhoneNumberTest.php
@@ -24,10 +24,10 @@ class PhoneNumberTest extends TestCase
     {
         $phoneNumber = new PhoneNumber();
 
-        $this->assertObjectHasAttribute('message', $phoneNumber);
-        $this->assertObjectHasAttribute('type', $phoneNumber);
-        $this->assertObjectHasAttribute('defaultRegion', $phoneNumber);
-        $this->assertObjectHasAttribute('regionPath', $phoneNumber);
+        $this->assertObjectHasProperty('message', $phoneNumber);
+        $this->assertObjectHasProperty('type', $phoneNumber);
+        $this->assertObjectHasProperty('defaultRegion', $phoneNumber);
+        $this->assertObjectHasProperty('regionPath', $phoneNumber);
     }
 
     /**

--- a/tests/Validator/Constraints/PhoneNumberValidatorTest.php
+++ b/tests/Validator/Constraints/PhoneNumberValidatorTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Validator\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 /**
@@ -68,8 +69,7 @@ class PhoneNumberValidatorTest extends TestCase
                 ->with($this->isType('string'))
                 ->willReturn($constraintViolationBuilder);
             $constraintViolationBuilder
-                ->method('addViolation')
-                ->willReturn($constraintViolationBuilder);
+                ->method('addViolation');
 
             $this->context
                 ->expects($this->once())
@@ -89,7 +89,13 @@ class PhoneNumberValidatorTest extends TestCase
     public function testValidateFromAttribute()
     {
         $classMetadata = new ClassMetadata(PhoneNumberDummy::class);
-        (new AnnotationLoader())->loadClassMetadata($classMetadata);
+        if (class_exists(AttributeLoader::class)) {
+            (new AttributeLoader())->loadClassMetadata($classMetadata);
+        } else {
+            // AnnotationLoader have been removed in favor of AttributeLoader in 7.0
+            /* @phpstan-ignore-next-line */
+            (new AnnotationLoader())->loadClassMetadata($classMetadata);
+        }
 
         [$constraint1] = $classMetadata->properties['phoneNumber1']->constraints;
         [$constraint2] = $classMetadata->properties['phoneNumber2']->constraints;


### PR DESCRIPTION
* Remove support for unmaintained [PHP](https://www.php.net/supported-versions.php) & [Symfony](https://symfony.com/releases) versions
* Support sf7.0

Tests failed for sf7.0 with dev dependencies (prophecy is probably not ready yet do deal with last debal verison? :thinking: ) and for php8.3, should I remove them or we can keep them for later?

IMO this PR should be merged after #154 & released in a new minor version.

Close #143 