### PR TITLE
Use root DI extension class

### DIFF
--- a/src/DependencyInjection/MisdPhoneNumberExtension.php
+++ b/src/DependencyInjection/MisdPhoneNumberExtension.php
@@ -15,8 +15,8 @@ namespace Misd\PhoneNumberBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * Bundle extension.


### PR DESCRIPTION
Symfony 7.1 deprecates the `Symfony\Component\HttpKernel\DependencyInjection\Extension` class in favor of the root `Symfony\Component\DependencyInjection\Extension\Extension` class, so this PR updates the DI extension to clear that deprecation.