### PR TITLE
Allow empty PhoneNumber object to be transformed in form

### DIFF
--- a/src/Form/DataTransformer/PhoneNumberToArrayTransformer.php
+++ b/src/Form/DataTransformer/PhoneNumberToArrayTransformer.php
@@ -51,6 +51,10 @@ class PhoneNumberToArrayTransformer implements DataTransformerInterface
             throw new TransformationFailedException('Expected a \libphonenumber\PhoneNumber.');
         }
 
+        if (!$value->hasCountryCode() && !$value->hasNationalNumber()) {
+            return ['country' => '', 'number' => ''];
+        }
+
         $util = PhoneNumberUtil::getInstance();
 
         if (false === \in_array($util->getRegionCodeForNumber($value), $this->countryChoices)) {


### PR DESCRIPTION
I have an entity that does not allow a NULL value for phone number:
```php
    #[ORM\Column(type: 'phone_number', nullable: false)]
    #[AssertPhoneNumber]
    private PhoneNumber $phone;
```

This change allows an empty PhoneNumber object to be transformed to be displayed on the form.