### PR TITLE
Allow to use PhoneNumber Constraint on methods

### DIFF
--- a/src/Validator/Constraints/PhoneNumber.php
+++ b/src/Validator/Constraints/PhoneNumber.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Constraint;
  * @Annotation
  * @NamedArgumentConstructor
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class PhoneNumber extends Constraint
 {
     public const ANY = 'any';


### PR DESCRIPTION
Hello and thanks for this bundle.

We used to use the `PhoneNumber` constraint on methods, but while migrating from Annotations to Attributes, this doesn't seem possible anymore.

This MR aims to fix that usage.

Thank you !