### PR TITLE
Update to libphonenumber 9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,15 @@
     },
     "require": {
         "php": ">=8.1",
-        "giggsey/libphonenumber-for-php": "^8.9",
+        "giggsey/libphonenumber-for-php": "^9.0.2",
         "symfony/framework-bundle": "^5.4 || ^6.3 || ^7.0",
         "symfony/intl": "^5.4 || ^6.3 || ^7.0",
         "symfony/polyfill-mbstring": "^1.28"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12|^2.0",
-        "phpspec/prophecy-phpunit": "^2.0",
+        "phpspec/prophecy-phpunit": "^2.3",
+        "phpspec/prophecy": "^1.20",
         "phpunit/phpunit": "^9.6.11",
         "symfony/form": "^5.4 || ^6.3 || ^7.0",
         "symfony/phpunit-bridge": "^7.0",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -73,7 +73,7 @@ class Configuration implements ConfigurationInterface
                             })->end()
                         ->end()
                         ->scalarNode('format')
-                            ->defaultValue(PhoneNumberFormat::E164)
+                            ->defaultValue(PhoneNumberFormat::E164->name)
                         ->end()
                     ->end()
                 ->end()
@@ -90,7 +90,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('format')
                             // The difference between serializer and validator is historical, they are here to keep the BC
-                            ->defaultValue(PhoneNumberFormat::INTERNATIONAL)
+                            ->defaultValue(PhoneNumberFormat::INTERNATIONAL->name)
                         ->end()
                     ->end()
                 ->end()

--- a/src/Doctrine/DBAL/Types/PhoneNumberType.php
+++ b/src/Doctrine/DBAL/Types/PhoneNumberType.php
@@ -71,7 +71,7 @@ class PhoneNumberType extends Type
         $util = PhoneNumberUtil::getInstance();
 
         try {
-            return $util->parse($value, PhoneNumberUtil::UNKNOWN_REGION);
+            return $util->parse($value);
         } catch (NumberParseException $e) {
             if (method_exists(ConversionException::class, 'conversionFailed')) {
                 // DBAL < 4

--- a/src/Form/DataTransformer/PhoneNumberToStringTransformer.php
+++ b/src/Form/DataTransformer/PhoneNumberToStringTransformer.php
@@ -26,11 +26,11 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 class PhoneNumberToStringTransformer implements DataTransformerInterface
 {
     private string $defaultRegion;
-    private int $format;
+    private PhoneNumberFormat $format;
 
     public function __construct(
         string $defaultRegion = PhoneNumberUtil::UNKNOWN_REGION,
-        int $format = PhoneNumberFormat::INTERNATIONAL,
+        PhoneNumberFormat $format = PhoneNumberFormat::INTERNATIONAL,
     ) {
         $this->defaultRegion = $defaultRegion;
         $this->format = $format;

--- a/src/Form/Type/PhoneNumberType.php
+++ b/src/Form/Type/PhoneNumberType.php
@@ -148,6 +148,7 @@ class PhoneNumberType extends AbstractType
             self::WIDGET_SINGLE_TEXT,
             self::WIDGET_COUNTRY_CHOICE,
         ]);
+        $resolver->setAllowedTypes('format', PhoneNumberFormat::class);
 
         $resolver->setAllowedValues('country_display_type', [
             self::DISPLAY_COUNTRY_FULL,

--- a/src/Serializer/Normalizer/PhoneNumberNormalizer.php
+++ b/src/Serializer/Normalizer/PhoneNumberNormalizer.php
@@ -29,14 +29,14 @@ class PhoneNumberNormalizer implements NormalizerInterface, DenormalizerInterfac
 {
     private PhoneNumberUtil $phoneNumberUtil;
     private string $region;
-    private int $format;
+    private PhoneNumberFormat $format;
 
     /**
-     * @param PhoneNumberUtil $phoneNumberUtil phone number utility
-     * @param string          $region          region code
-     * @param int             $format          display format
+     * @param PhoneNumberUtil   $phoneNumberUtil phone number utility
+     * @param string            $region          region code
+     * @param PhoneNumberFormat $format          display format
      */
-    public function __construct(PhoneNumberUtil $phoneNumberUtil, string $region = PhoneNumberUtil::UNKNOWN_REGION, int $format = PhoneNumberFormat::E164)
+    public function __construct(PhoneNumberUtil $phoneNumberUtil, string $region = PhoneNumberUtil::UNKNOWN_REGION, PhoneNumberFormat $format = PhoneNumberFormat::E164)
     {
         $this->phoneNumberUtil = $phoneNumberUtil;
         $this->region = $region;

--- a/src/Templating/Helper/PhoneNumberHelper.php
+++ b/src/Templating/Helper/PhoneNumberHelper.php
@@ -15,7 +15,6 @@ namespace Misd\PhoneNumberBundle\Templating\Helper;
 
 use libphonenumber\PhoneNumber;
 use libphonenumber\PhoneNumberFormat;
-use libphonenumber\PhoneNumberType;
 use libphonenumber\PhoneNumberUtil;
 use Misd\PhoneNumberBundle\Exception\InvalidArgumentException;
 
@@ -31,18 +30,16 @@ class PhoneNumberHelper
         $this->phoneNumberUtil = $phoneNumberUtil;
     }
 
-    public function format(PhoneNumber|string $phoneNumber, string|int $format = PhoneNumberFormat::INTERNATIONAL): string
+    public function format(PhoneNumber|string $phoneNumber, int|PhoneNumberFormat $format = PhoneNumberFormat::INTERNATIONAL): string
     {
         $phoneNumber = $this->getPhoneNumber($phoneNumber);
 
-        if (true === \is_string($format)) {
-            $constant = '\libphonenumber\PhoneNumberFormat::'.$format;
-
-            if (false === \defined($constant)) {
-                throw new InvalidArgumentException('The format must be either a constant value or name in libphonenumber\PhoneNumberFormat');
+        if (true === \is_int($format)) {
+            try {
+                $format = PhoneNumberFormat::from($format);
+            } catch (\ValueError $error) {
+                throw new InvalidArgumentException('The format must be either a constant value or enum in libphonenumber\PhoneNumberFormat');
             }
-
-            $format = \constant('\libphonenumber\PhoneNumberFormat::'.$format);
         }
 
         return $this->phoneNumberUtil->format($phoneNumber, $format);
@@ -67,7 +64,7 @@ class PhoneNumberHelper
      *
      * @throws InvalidArgumentException if type argument is invalid
      */
-    public function isType($phoneNumber, $type = PhoneNumberType::UNKNOWN): bool
+    public function isType($phoneNumber, $type = PhoneNumberUtil::UNKNOWN_REGION): bool
     {
         $phoneNumber = $this->getPhoneNumber($phoneNumber);
 

--- a/src/Validator/Constraints/PhoneNumber.php
+++ b/src/Validator/Constraints/PhoneNumber.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Misd\PhoneNumberBundle\Validator\Constraints;
 
+use libphonenumber\PhoneNumberFormat;
 use Misd\PhoneNumberBundle\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
@@ -51,16 +52,16 @@ class PhoneNumber extends Constraint
     public string|array $type = self::ANY;
     public ?string $defaultRegion = null;
     public ?string $regionPath = null;
-    public ?int $format = null;
+    public ?PhoneNumberFormat $format = null;
 
     /**
-     * @param int|null             $format  Specify the format (\libphonenumber\PhoneNumberFormat::*)
-     * @param string|string[]|null $type
-     * @param array<mixed>         $options
+     * @param PhoneNumberFormat|null $format  Specify the format (\libphonenumber\PhoneNumberFormat::*)
+     * @param string|string[]|null   $type
+     * @param array<mixed>           $options
      */
     #[HasNamedArguments]
     public function __construct(
-        ?int $format = null,
+        ?PhoneNumberFormat $format = null,
         string|array|null $type = null,
         ?string $defaultRegion = null,
         ?string $regionPath = null,

--- a/src/Validator/Constraints/PhoneNumberValidator.php
+++ b/src/Validator/Constraints/PhoneNumberValidator.php
@@ -36,12 +36,12 @@ class PhoneNumberValidator extends ConstraintValidator
     private PhoneNumberUtil $phoneUtil;
     private string $defaultRegion;
     private ?PropertyAccessorInterface $propertyAccessor = null;
-    private int $format;
+    private PhoneNumberFormat $format;
 
     public function __construct(
         ?PhoneNumberUtil $phoneUtil = null,
         string $defaultRegion = PhoneNumberUtil::UNKNOWN_REGION,
-        int $format = PhoneNumberFormat::INTERNATIONAL,
+        PhoneNumberFormat $format = PhoneNumberFormat::INTERNATIONAL,
     ) {
         $this->phoneUtil = $phoneUtil ?? PhoneNumberUtil::getInstance();
         $this->defaultRegion = $defaultRegion;
@@ -120,8 +120,6 @@ class PhoneNumberValidator extends ConstraintValidator
                     break;
             }
         }
-
-        $validTypes = array_unique($validTypes);
 
         if (0 < \count($validTypes)) {
             $type = $this->phoneUtil->getNumberType($phoneNumber);

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -49,12 +49,12 @@ class ConfigurationTest extends TestCase
             'serializer' => [
                 'enabled' => true,
                 'default_region' => 'ZZ',
-                'format' => PhoneNumberFormat::E164,
+                'format' => PhoneNumberFormat::E164->name,
             ],
             'validator' => [
                 'enabled' => true,
                 'default_region' => 'ZZ',
-                'format' => PhoneNumberFormat::INTERNATIONAL,
+                'format' => PhoneNumberFormat::INTERNATIONAL->name,
             ],
         ]];
 
@@ -75,12 +75,12 @@ class ConfigurationTest extends TestCase
             'serializer' => [
                 'enabled' => false,
                 'default_region' => 'ZZ',
-                'format' => PhoneNumberFormat::E164,
+                'format' => PhoneNumberFormat::E164->name,
             ],
             'validator' => [
                 'enabled' => false,
                 'default_region' => 'ZZ',
-                'format' => PhoneNumberFormat::INTERNATIONAL,
+                'format' => PhoneNumberFormat::INTERNATIONAL->name,
             ],
         ]];
 
@@ -95,12 +95,12 @@ class ConfigurationTest extends TestCase
                 'serializer' => [
                     'enabled' => false,
                     'default_region' => 'GB',
-                    'format' => PhoneNumberFormat::E164,
+                    'format' => PhoneNumberFormat::E164->name,
                 ],
                 'validator' => [
                     'enabled' => false,
                     'default_region' => 'GB',
-                    'format' => PhoneNumberFormat::INTERNATIONAL,
+                    'format' => PhoneNumberFormat::INTERNATIONAL->name,
                 ],
             ],
         ], [
@@ -113,12 +113,12 @@ class ConfigurationTest extends TestCase
             'serializer' => [
                 'enabled' => false,
                 'default_region' => 'GB',
-                'format' => PhoneNumberFormat::E164,
+                'format' => PhoneNumberFormat::E164->name,
             ],
             'validator' => [
                 'enabled' => false,
                 'default_region' => 'GB',
-                'format' => PhoneNumberFormat::INTERNATIONAL,
+                'format' => PhoneNumberFormat::INTERNATIONAL->name,
             ],
         ]];
     }

--- a/tests/DependencyInjection/MisdPhoneNumberExtensionTest.php
+++ b/tests/DependencyInjection/MisdPhoneNumberExtensionTest.php
@@ -89,13 +89,13 @@ class MisdPhoneNumberExtensionTest extends TestCase
             'misd_phone_number' => [
                 'validator' => [
                     'default_region' => 'GB',
-                    'format' => PhoneNumberFormat::E164,
+                    'format' => PhoneNumberFormat::E164->name,
                 ],
             ],
         ], $this->container);
 
         $this->assertSame('GB', $this->container->getParameter('misd_phone_number.validator.default_region'));
-        $this->assertSame(0, $this->container->getParameter('misd_phone_number.validator.format'));
+        $this->assertSame(PhoneNumberFormat::E164->name, $this->container->getParameter('misd_phone_number.validator.format'));
     }
 
     public function testNormalizerParameters(): void
@@ -106,13 +106,13 @@ class MisdPhoneNumberExtensionTest extends TestCase
             'misd_phone_number' => [
                 'serializer' => [
                     'default_region' => 'FR',
-                    'format' => PhoneNumberFormat::INTERNATIONAL,
+                    'format' => PhoneNumberFormat::INTERNATIONAL->name,
                 ],
             ],
         ], $this->container);
 
         $this->assertSame('FR', $this->container->getParameter('misd_phone_number.serializer.default_region'));
-        $this->assertSame(PhoneNumberFormat::INTERNATIONAL, $this->container->getParameter('misd_phone_number.serializer.format'));
+        $this->assertSame(PhoneNumberFormat::INTERNATIONAL->name, $this->container->getParameter('misd_phone_number.serializer.format'));
     }
 
     public function testValidatorDefaultRegionUppercase(): void

--- a/tests/Doctrine/DBAL/Types/PhoneNumberTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/PhoneNumberTypeTest.php
@@ -89,7 +89,7 @@ class PhoneNumberTypeTest extends TestCase
 
     public function testConvertToDatabaseValueWithPhoneNumber(): void
     {
-        $phoneNumber = $this->phoneNumberUtil->parse('+441234567890', PhoneNumberUtil::UNKNOWN_REGION);
+        $phoneNumber = $this->phoneNumberUtil->parse('+441234567890');
 
         $this->assertSame('+441234567890', $this->type->convertToDatabaseValue($phoneNumber, $this->platform->reveal()));
     }
@@ -116,7 +116,7 @@ class PhoneNumberTypeTest extends TestCase
 
     public function testConvertToPHPValueWithAPhoneNumberInstance(): void
     {
-        $expectedPhoneNumber = $this->phoneNumberUtil->parse('+441234567890', PhoneNumberUtil::UNKNOWN_REGION);
+        $expectedPhoneNumber = $this->phoneNumberUtil->parse('+441234567890');
 
         $phoneNumber = $this->type->convertToPHPValue($expectedPhoneNumber, $this->platform->reveal());
 

--- a/tests/Form/DataTransformer/PhoneNumberToStringTransformerTest.php
+++ b/tests/Form/DataTransformer/PhoneNumberToStringTransformerTest.php
@@ -45,14 +45,17 @@ class PhoneNumberToStringTransformerTest extends TestCase
     /**
      * @dataProvider transformProvider
      */
-    public function testTransform(string $defaultRegion, int $format, ?string $actual, string $expected): void
+    public function testTransform(string $defaultRegion, PhoneNumberFormat $format, ?string $actual, string $expected): void
     {
         $transformer = new PhoneNumberToStringTransformer($defaultRegion, $format);
 
         $phoneNumberUtil = PhoneNumberUtil::getInstance();
         try {
-            /* @phpstan-ignore-next-line */
-            $phoneNumber = $phoneNumberUtil->parse($actual, $defaultRegion);
+            if (null !== $actual) {
+                $phoneNumber = $phoneNumberUtil->parse($actual, $defaultRegion);
+            } else {
+                $phoneNumber = $actual;
+            }
         } catch (NumberParseException $e) {
             $phoneNumber = $actual;
         }
@@ -73,7 +76,7 @@ class PhoneNumberToStringTransformerTest extends TestCase
      * 2 => Actual value
      * 3 => Expected result.
      *
-     * @return iterable<array{string, int, ?string, string}>
+     * @return iterable<array{string, PhoneNumberFormat, ?string, string}>
      */
     public function transformProvider(): iterable
     {

--- a/tests/Templating/Helper/PhoneNumberHelperTest.php
+++ b/tests/Templating/Helper/PhoneNumberHelperTest.php
@@ -44,7 +44,7 @@ class PhoneNumberHelperTest extends TestCase
     /**
      * @dataProvider processProvider
      */
-    public function testProcess(int|string $format, int $expectedFormat): void
+    public function testProcess(PhoneNumberFormat|int $format, PhoneNumberFormat $expectedFormat): void
     {
         $phoneNumber = $this->prophesize(PhoneNumber::class);
         $this->phoneNumberUtil
@@ -59,12 +59,12 @@ class PhoneNumberHelperTest extends TestCase
      * 0 => Format
      * 1 => Expected format.
      *
-     * @return iterable<array{string|int, int}>
+     * @return iterable<array{PhoneNumberFormat|int, PhoneNumberFormat}>
      */
     public function processProvider(): iterable
     {
         yield [PhoneNumberFormat::NATIONAL, PhoneNumberFormat::NATIONAL];
-        yield ['NATIONAL', PhoneNumberFormat::NATIONAL];
+        yield [PhoneNumberFormat::NATIONAL->value, PhoneNumberFormat::NATIONAL];
     }
 
     public function testProcessInvalidArgumentException(): void
@@ -73,13 +73,13 @@ class PhoneNumberHelperTest extends TestCase
 
         $phoneNumber = $this->prophesize(PhoneNumber::class);
 
-        $this->helper->format($phoneNumber->reveal(), 'foo');
+        $this->helper->format($phoneNumber->reveal(), 999);
     }
 
     /**
      * @dataProvider formatOutOfCountryCallingNumberProvider
      */
-    public function testFormatOutOfCountryCallingNumber(string $phoneNumber, string $defaultRegion, ?string $regionCode, string $expectedResult): void
+    public function testFormatOutOfCountryCallingNumber(string $phoneNumber, string $defaultRegion, string $regionCode, string $expectedResult): void
     {
         $phoneNumberUtil = PhoneNumberUtil::getInstance();
         $helper = new PhoneNumberHelper($phoneNumberUtil);
@@ -101,6 +101,6 @@ class PhoneNumberHelperTest extends TestCase
     {
         yield ['1-800-854-3680', 'US', 'US', '1 (800) 854-3680'];
         yield ['1-800-854-3680', 'US', 'NL', '00 1 800-854-3680'];
-        yield ['1-800-854-3680', 'US', null, '+1 800-854-3680'];
+        yield ['1-800-854-3680', 'US', 'ZZ', '+1 800-854-3680'];
     }
 }

--- a/tests/Validator/Constraints/PhoneNumberTest.php
+++ b/tests/Validator/Constraints/PhoneNumberTest.php
@@ -37,7 +37,7 @@ class PhoneNumberTest extends TestCase
      *
      * @param string|string[]|null $type
      */
-    public function testMessage(?string $message, string|array|null $type, ?int $format, string $expectedMessage): void
+    public function testMessage(?string $message, string|array|null $type, ?PhoneNumberFormat $format, string $expectedMessage): void
     {
         $phoneNumber = new PhoneNumber($format, $type, null, null, $message);
         $this->assertSame($expectedMessage, $phoneNumber->getMessage());
@@ -50,7 +50,7 @@ class PhoneNumberTest extends TestCase
      * 2 => Format (optional)
      * 3 => Expected message.
      *
-     * @return iterable<array{?string, string|string[]|null, ?int, string}>
+     * @return iterable<array{?string, string|string[]|null, ?PhoneNumberFormat, string}>
      */
     public function messageProvider(): iterable
     {

--- a/tests/Validator/Constraints/PhoneNumberValidatorTest.php
+++ b/tests/Validator/Constraints/PhoneNumberValidatorTest.php
@@ -56,7 +56,7 @@ class PhoneNumberValidatorTest extends TestCase
         array|string|null $type = null,
         ?string $defaultRegion = null,
         ?string $regionPath = null,
-        ?int $format = null,
+        ?PhoneNumberFormat $format = null,
     ): void {
         $constraint = new PhoneNumber($format, $type, $defaultRegion, $regionPath);
 
@@ -113,7 +113,7 @@ class PhoneNumberValidatorTest extends TestCase
      * 3 => Default region (optional).
      * 4 => Region Path (optional).
      *
-     * @return iterable<array{string|LibPhoneNumber|null, bool, 2?: string|string[]|null, 3?: ?string, 4?: ?string, 5?: ?int}>
+     * @return iterable<array{string|LibPhoneNumber|null, bool, 2?: string|string[]|null, 3?: ?string, 4?: ?string, 5?: ?PhoneNumberFormat}>
      */
     public function validateProvider(): iterable
     {


### PR DESCRIPTION
Hello guys!

The library libphonenumber has been upgraded! So I started to work on how to upgrade it. And ootch. It breaks a lot! But this PR fixes https://github.com/odolbeau/phone-number-bundle/issues/185 !

I think what we need to do on our side is a new major version because I don't think people are specifying the version of the phone number library they use.

I also think this is a a draft for now because it still requires:
- A guide for an upgrade path
- Updated documentation
- A lot of tests and verfications

We should probably think to bump the PHP version and maybe work on the following issues for a new major of this bundle:
- [x] https://github.com/odolbeau/phone-number-bundle/issues/145
- [x] https://github.com/odolbeau/phone-number-bundle/issues/118
- [x] https://github.com/odolbeau/phone-number-bundle/issues/153
- [x] https://github.com/odolbeau/phone-number-bundle/issues/178
- [x] https://github.com/odolbeau/phone-number-bundle/issues/184
- [ ] BC layers should be removed!

And finally, would be super-great and is a real break:
- [x] https://github.com/odolbeau/phone-number-bundle/issues/144

This PR has been updated but needs #189 first.