### PR TITLE
fix(serializer): improve error handling for invalid phone number input

### DIFF
--- a/src/Validator/Constraints/PhoneNumber.php
+++ b/src/Validator/Constraints/PhoneNumber.php
@@ -68,7 +68,7 @@ class PhoneNumber extends Constraint
         ?string $message = null,
         ?array $groups = null,
         $payload = null,
-        array $options = [],
+        ?array $options = null,
     ) {
         parent::__construct($options, $groups, $payload);
 


### PR DESCRIPTION
Fix https://github.com/odolbeau/phone-number-bundle/issues/178

This improves compatibility with MapRequestPayload, for example, and tolerant deserialization flows when collect_denormalization_errors is set to true.

Instead of throwing immediately on NumberParseException, the denormalizer now records the error in the not_normalizable_value_exceptions context array and returns a PhoneNumber instance with only the raw input set. This allows to handle the error later without interrupting the deserialization process.

poke @Lochar 