### PR TITLE
Fix form type equality checks with array form data

### DIFF
--- a/src/Form/Extension/PhoneNumberTypeEqualityExtension.php
+++ b/src/Form/Extension/PhoneNumberTypeEqualityExtension.php
@@ -42,21 +42,21 @@ class PhoneNumberTypeEqualityExtension extends AbstractTypeExtension
             $newPhoneNumber = $event->getData();
 
             $parentForm = $event->getForm()->getParent();
-            $propertyName = $event->getForm()->getName();
+            $propertyPath = $event->getForm()->getPropertyPath();
 
             if (!$parentForm) {
                 return;
             }
 
             $original = $parentForm->getData();
-            if (!$original || !$propertyName) {
+            if (!$original || !$propertyPath) {
                 return;
             }
 
-            if ($this->propertyAccessor->isReadable($original, $propertyName)) {
-                $originalPhoneNumber = $this->propertyAccessor->getValue($original, $propertyName);
+            if ($this->propertyAccessor->isReadable($original, $propertyPath)) {
+                $originalPhoneNumber = $this->propertyAccessor->getValue($original, $propertyPath);
             } else {
-                trigger_deprecation('odolbeau/phone-number-bundle', '4.2', 'Could not access property "%s" on class "%s". Make sure it is readable or add a getter method.', $propertyName, $original::class);
+                trigger_deprecation('odolbeau/phone-number-bundle', '4.2', 'Could not access property "%s" on "%s". Make sure it is readable or add a getter method.', $propertyPath, get_debug_type($original));
 
                 return;
             }

--- a/tests/Form/Extension/PhoneNumberTypeEqualityExtensionTest.php
+++ b/tests/Form/Extension/PhoneNumberTypeEqualityExtensionTest.php
@@ -31,7 +31,7 @@ class PhoneNumberTypeEqualityExtensionTest extends TypeTestCase
         ];
     }
 
-    public function testNoChangeKeepsOriginalInstance(): void
+    public function testNoChangeInObjectKeepsOriginalInstance(): void
     {
         $phone = new PhoneNumber();
         $phone->setCountryCode(33);
@@ -65,5 +65,24 @@ class PhoneNumberTypeEqualityExtensionTest extends TypeTestCase
         $form->submit(['phoneNumber' => '+33612345678']);
 
         $this->assertSame($entity->getPhoneNumber(), $phone);
+    }
+
+    public function testNoChangeInArrayKeepsOriginalInstance(): void
+    {
+        $phone = new PhoneNumber();
+        $phone->setCountryCode(33);
+        $phone->setNationalNumber('612345678');
+
+        $data = ['phoneNumber' => $phone];
+
+        $form = $this->factory->createBuilder(FormType::class, $data)
+            ->add('phoneNumber', PhoneNumberType::class, [
+                'number_type' => PhoneNumberType::NUMBER_TYPE_TEL,
+            ])
+            ->getForm();
+
+        $form->submit(['phoneNumber' => '+33612345678']);
+
+        $this->assertSame($data['phoneNumber'], $phone);
     }
 }


### PR DESCRIPTION
When form data ends up in an array shape and not an object, the new `PhoneNumberTypeEqualityExtension` wouldn't be able to read the original phone number and try to trigger the deprecation for not being able to read the data, but the deprecation message would create a `TypeError` processing `$original::class` because `$original` in this case is an array.

By using the property path instead of the name, this allows the extension to work with both arrays and objects (the added test case fails with the below error without this change).

```sh
There was 1 error:

1) Misd\PhoneNumberBundle\Tests\Form\Extension\PhoneNumberTypeEqualityExtensionTest::testNoChangeInArrayKeepsOriginalInstance
   TypeError: Cannot use "::class" on array

/src/Form/Extension/PhoneNumberTypeEqualityExtension.php:59
/vendor/symfony/event-dispatcher/EventDispatcher.php:206
/vendor/symfony/event-dispatcher/EventDispatcher.php:56
/vendor/symfony/event-dispatcher/ImmutableEventDispatcher.php:28
/vendor/symfony/form/Form.php:558
/vendor/symfony/form/Form.php:493
/tests/Form/Extension/PhoneNumberTypeEqualityExtensionTest.php:84
```