### PR TITLE
Fix #198 - documentation for PN9 enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The `phone_number_format` filter can be used to format a phone number object. A 
 For example, to format an object called `myPhoneNumber` in the `libphonenumber\PhoneNumberFormat::NATIONAL` format:
 
 ```php
-{{ myPhoneNumber|phone_number_format('NATIONAL') }}
+{{ myPhoneNumber|phone_number_format(constant('libphonenumber\PhoneNumberFormat::NATIONAL')) }}
 ```
 
 By default phone numbers are formatted in the `libphonenumber\PhoneNumberFormat::INTERNATIONAL` format.


### PR DESCRIPTION
We forgot to update the documentation after https://github.com/odolbeau/phone-number-bundle/pull/193 . 

That said... Supporting strings or int does not sound bad for me. Maybe we should just remove the deprecation trigger?