### PR TITLE
Update test suite (sf 7.3 + PHP 8.4)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,12 @@ jobs:
           - php: 8.3
             symfony-require: 7.2.*
             composer-flags: '--prefer-stable --ignore-platform-req=php+'
+          - php: 8.4
+            symfony-require: 7.3.*
+            composer-flags: '--prefer-stable'
           # Development release
           - php: nightly
-            symfony-require: 7.3.*@dev
+            symfony-require: 7.4.*@dev
             composer-flags: '--ignore-platform-req=php+'
             stability: dev
             can-fail: true


### PR DESCRIPTION
The failure is connected to Symfony removing internal public access. But the test on our side is not well designed. We need to work on it for a bit.