### PR TITLE
Fix CI by adding a minimum version of ICU

### DIFF
--- a/tests/Form/Type/PhoneNumberTypeTest.php
+++ b/tests/Form/Type/PhoneNumberTypeTest.php
@@ -16,6 +16,7 @@ namespace Misd\PhoneNumberBundle\Tests\Form\Type;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
 use Misd\PhoneNumberBundle\Form\Type\PhoneNumberType;
+use Misd\PhoneNumberBundle\Tests\PhoneNumberSuiteConfig;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -136,7 +137,7 @@ class PhoneNumberTypeTest extends TestCase
      */
     public function testCountryChoiceChoices(array $choices, int $expectedChoicesCount, array $expectedChoices): void
     {
-        IntlTestHelper::requireIntl($this);
+        IntlTestHelper::requireIntl($this, PhoneNumberSuiteConfig::ICU_MINIMUM_VERSION);
 
         $form = $this->factory->create(
             PhoneNumberType::class,
@@ -258,7 +259,7 @@ class PhoneNumberTypeTest extends TestCase
      */
     public function testCountryChoicePlaceholder(?string $placeholder, ?string $expectedPlaceholder): void
     {
-        IntlTestHelper::requireIntl($this);
+        IntlTestHelper::requireIntl($this, PhoneNumberSuiteConfig::ICU_MINIMUM_VERSION);
         $form = $this->factory->create(PhoneNumberType::class, null, [
             'widget' => PhoneNumberType::WIDGET_COUNTRY_CHOICE,
             'country_placeholder' => $placeholder,
@@ -286,7 +287,7 @@ class PhoneNumberTypeTest extends TestCase
 
     public function testCountryChoiceTranslations(): void
     {
-        IntlTestHelper::requireFullIntl($this);
+        IntlTestHelper::requireFullIntl($this, PhoneNumberSuiteConfig::ICU_MINIMUM_VERSION);
         \Locale::setDefault('fr');
 
         $form = $this->factory->create(PhoneNumberType::class, null, [

--- a/tests/PhoneNumberSuiteConfig.php
+++ b/tests/PhoneNumberSuiteConfig.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Misd\PhoneNumberBundle\Tests;
+
+final class PhoneNumberSuiteConfig
+{
+    public const ICU_MINIMUM_VERSION = '75';
+}


### PR DESCRIPTION
This is a missing config inside the test suite
not specifying the ICU version used result in a default required version that is too high for most systems (including last ubuntu versions and our CI!)