### PR TITLE
feat(validator): add validation option for isPossibleNumber vs isValidNumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,17 @@ private $mobilePhoneNumber;
 private $fixedOrVoipPhoneNumber;
 ```
 
+By default, validation uses libphonenumber’s `isValidNumber()` (constraint value `AssertPhoneNumber::IS_VALID_NUMBER`). You can relax this to `isPossibleNumber()` with `AssertPhoneNumber::IS_POSSIBLE_NUMBER` — useful when you want to accept numbers that match length and national format but are not (yet) assigned in the numbering plan.
+
+```php
+use Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumber as AssertPhoneNumber;
+
+#[AssertPhoneNumber(validation: AssertPhoneNumber::IS_POSSIBLE_NUMBER)]
+private $phoneNumber;
+```
+
+**Warning:** `IS_POSSIBLE_NUMBER` is more permissive than `IS_VALID_NUMBER`. It does not guarantee that the number is actually allocated or dialable as a real subscriber line. If you also restrict `type` (e.g. mobile vs fixed-line), a “possible but not valid” number may still fail validation when `getNumberType()` does not match — this avoids silently accepting ambiguous input.
+
 ### Translations
 
 The bundle contains translations for the form field and validation constraints.

--- a/README.md
+++ b/README.md
@@ -268,16 +268,16 @@ private $mobilePhoneNumber;
 private $fixedOrVoipPhoneNumber;
 ```
 
-By default, validation uses libphonenumber’s `isValidNumber()` (constraint value `AssertPhoneNumber::IS_VALID_NUMBER`). You can relax this to `isPossibleNumber()` with `AssertPhoneNumber::IS_POSSIBLE_NUMBER` — useful when you want to accept numbers that match length and national format but are not (yet) assigned in the numbering plan.
+By default, validation uses libphonenumber’s `isValidNumber()` (constraint value `Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumber::VALIDATION_TYPE_VALID_NUMBER`, or `AssertPhoneNumber::VALIDATION_TYPE_VALID_NUMBER` when using the usual alias). You can relax this to `isPossibleNumber()` with `VALIDATION_TYPE_POSSIBLE_NUMBER` — useful when you want to accept numbers that match length and national format but are not (yet) assigned in the numbering plan.
 
 ```php
 use Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumber as AssertPhoneNumber;
 
-#[AssertPhoneNumber(validation: AssertPhoneNumber::IS_POSSIBLE_NUMBER)]
+#[AssertPhoneNumber(validationType: AssertPhoneNumber::VALIDATION_TYPE_POSSIBLE_NUMBER)]
 private $phoneNumber;
 ```
 
-**Warning:** `IS_POSSIBLE_NUMBER` is more permissive than `IS_VALID_NUMBER`. It does not guarantee that the number is actually allocated or dialable as a real subscriber line. If you also restrict `type` (e.g. mobile vs fixed-line), a “possible but not valid” number may still fail validation when `getNumberType()` does not match — this avoids silently accepting ambiguous input.
+**Warning:** `VALIDATION_TYPE_POSSIBLE_NUMBER` is more permissive than `VALIDATION_TYPE_VALID_NUMBER`. It does not guarantee that the number is actually allocated or dialable as a real subscriber line. If you also restrict `type` (e.g. mobile vs fixed-line), a “possible but not valid” number may still fail validation when `getNumberType()` does not match — this avoids silently accepting ambiguous input.
 
 ### Translations
 

--- a/src/Validator/Constraints/PhoneNumber.php
+++ b/src/Validator/Constraints/PhoneNumber.php
@@ -39,6 +39,9 @@ class PhoneNumber extends Constraint
     public const VOIP = 'voip';
     public const VOICEMAIL = 'voicemail';
 
+    public const IS_VALID_NUMBER = 'isValidNumber';
+    public const IS_POSSIBLE_NUMBER = 'isPossibleNumber';
+
     public const INVALID_PHONE_NUMBER_ERROR = 'ca23f4ca-38f4-4325-9bcc-eb570a4abe7f';
 
     protected const ERROR_NAMES = [
@@ -54,10 +57,12 @@ class PhoneNumber extends Constraint
     public ?string $regionPath = null;
     public ?string $requiredRegion = null;
     public ?PhoneNumberFormat $format = null;
+    public string $validation = self::IS_VALID_NUMBER;
 
     /**
-     * @param PhoneNumberFormat|null $format  Specify the format (\libphonenumber\PhoneNumberFormat::*)
+     * @param PhoneNumberFormat|null $format     Specify the format (\libphonenumber\PhoneNumberFormat::*)
      * @param string|string[]|null   $type
+     * @param string|null            $validation One of self::IS_VALID_NUMBER (default) or self::IS_POSSIBLE_NUMBER
      * @param array<mixed>           $options
      */
     #[HasNamedArguments]
@@ -71,6 +76,7 @@ class PhoneNumber extends Constraint
         $payload = null,
         ?array $options = null,
         ?string $requiredRegion = null,
+        ?string $validation = null,
     ) {
         parent::__construct($options, $groups, $payload);
 
@@ -85,6 +91,7 @@ class PhoneNumber extends Constraint
         $this->defaultRegion = $defaultRegion ?? $this->defaultRegion;
         $this->regionPath = $regionPath ?? $this->regionPath;
         $this->requiredRegion = $requiredRegion ?? $this->requiredRegion;
+        $this->validation = $validation ?? $this->validation;
     }
 
     /**

--- a/src/Validator/Constraints/PhoneNumber.php
+++ b/src/Validator/Constraints/PhoneNumber.php
@@ -63,7 +63,7 @@ class PhoneNumber extends Constraint
     public string $validationType = self::VALIDATION_TYPE_VALID_NUMBER;
 
     /**
-     * @param PhoneNumberFormat|null $format     Specify the format (\libphonenumber\PhoneNumberFormat::*)
+     * @param PhoneNumberFormat|null $format         Specify the format (\libphonenumber\PhoneNumberFormat::*)
      * @param string|string[]|null   $type
      * @param string|null            $validationType One of self::VALIDATION_TYPE_VALID_NUMBER (default) or self::VALIDATION_TYPE_POSSIBLE_NUMBER
      * @param array<mixed>           $options

--- a/src/Validator/Constraints/PhoneNumber.php
+++ b/src/Validator/Constraints/PhoneNumber.php
@@ -39,8 +39,8 @@ class PhoneNumber extends Constraint
     public const VOIP = 'voip';
     public const VOICEMAIL = 'voicemail';
 
-    public const IS_VALID_NUMBER = 'isValidNumber';
-    public const IS_POSSIBLE_NUMBER = 'isPossibleNumber';
+    public const VALIDATION_TYPE_VALID_NUMBER = 'isValidNumber';
+    public const VALIDATION_TYPE_POSSIBLE_NUMBER = 'isPossibleNumber';
 
     public const INVALID_PHONE_NUMBER_ERROR = 'ca23f4ca-38f4-4325-9bcc-eb570a4abe7f';
 
@@ -57,12 +57,15 @@ class PhoneNumber extends Constraint
     public ?string $regionPath = null;
     public ?string $requiredRegion = null;
     public ?PhoneNumberFormat $format = null;
-    public string $validation = self::IS_VALID_NUMBER;
+    /**
+     * One of `self::VALIDATION_TYPE_VALID_NUMBER` or `self::VALIDATION_TYPE_POSSIBLE_NUMBER`.
+     */
+    public string $validationType = self::VALIDATION_TYPE_VALID_NUMBER;
 
     /**
      * @param PhoneNumberFormat|null $format     Specify the format (\libphonenumber\PhoneNumberFormat::*)
      * @param string|string[]|null   $type
-     * @param string|null            $validation One of self::IS_VALID_NUMBER (default) or self::IS_POSSIBLE_NUMBER
+     * @param string|null            $validationType One of self::VALIDATION_TYPE_VALID_NUMBER (default) or self::VALIDATION_TYPE_POSSIBLE_NUMBER
      * @param array<mixed>           $options
      */
     #[HasNamedArguments]
@@ -76,7 +79,7 @@ class PhoneNumber extends Constraint
         $payload = null,
         ?array $options = null,
         ?string $requiredRegion = null,
-        ?string $validation = null,
+        ?string $validationType = null,
     ) {
         parent::__construct($options, $groups, $payload);
 
@@ -91,7 +94,7 @@ class PhoneNumber extends Constraint
         $this->defaultRegion = $defaultRegion ?? $this->defaultRegion;
         $this->regionPath = $regionPath ?? $this->regionPath;
         $this->requiredRegion = $requiredRegion ?? $this->requiredRegion;
-        $this->validation = $validation ?? $this->validation;
+        $this->validationType = $validationType ?? $this->validationType;
     }
 
     /**

--- a/src/Validator/Constraints/PhoneNumberValidator.php
+++ b/src/Validator/Constraints/PhoneNumberValidator.php
@@ -82,25 +82,24 @@ class PhoneNumberValidator extends ConstraintValidator
             $value = $this->phoneUtil->format($phoneNumber, $constraint->format ?? $this->format);
         }
 
-        if (PhoneNumberConstraint::IS_POSSIBLE_NUMBER === $constraint->validation) {
+        if (PhoneNumberConstraint::VALIDATION_TYPE_POSSIBLE_NUMBER === $constraint->validationType) {
             if (false === $this->phoneUtil->isPossibleNumber($phoneNumber)) {
                 $this->addViolation($value, $constraint);
 
                 return;
             }
-        } elseif (false === $this->phoneUtil->isValidNumber($phoneNumber)) {
-            $this->addViolation($value, $constraint);
+        } else {
+            if (false === $this->phoneUtil->isValidNumber($phoneNumber)) {
+                $this->addViolation($value, $constraint);
 
-            return;
+                return;
+            }
         }
 
         if (null !== $constraint->requiredRegion && false === $this->phoneUtil->isValidNumberForRegion($phoneNumber, $constraint->requiredRegion)) {
             $this->addViolation($value, $constraint);
         }
 
-        // When validation is IS_POSSIBLE_NUMBER, a number may pass isPossibleNumber() but not isValidNumber().
-        // getNumberType() can then be UNKNOWN or otherwise not match a restricted type; we still require a
-        // matching type so the constraint does not silently accept ambiguous numbers.
         $validTypes = [];
         foreach ($constraint->getTypes() as $type) {
             switch ($type) {

--- a/src/Validator/Constraints/PhoneNumberValidator.php
+++ b/src/Validator/Constraints/PhoneNumberValidator.php
@@ -82,7 +82,13 @@ class PhoneNumberValidator extends ConstraintValidator
             $value = $this->phoneUtil->format($phoneNumber, $constraint->format ?? $this->format);
         }
 
-        if (false === $this->phoneUtil->isValidNumber($phoneNumber)) {
+        if (PhoneNumberConstraint::IS_POSSIBLE_NUMBER === $constraint->validation) {
+            if (false === $this->phoneUtil->isPossibleNumber($phoneNumber)) {
+                $this->addViolation($value, $constraint);
+
+                return;
+            }
+        } elseif (false === $this->phoneUtil->isValidNumber($phoneNumber)) {
             $this->addViolation($value, $constraint);
 
             return;
@@ -92,6 +98,9 @@ class PhoneNumberValidator extends ConstraintValidator
             $this->addViolation($value, $constraint);
         }
 
+        // When validation is IS_POSSIBLE_NUMBER, a number may pass isPossibleNumber() but not isValidNumber().
+        // getNumberType() can then be UNKNOWN or otherwise not match a restricted type; we still require a
+        // matching type so the constraint does not silently accept ambiguous numbers.
         $validTypes = [];
         foreach ($constraint->getTypes() as $type) {
             switch ($type) {

--- a/tests/Validator/Constraints/PhoneNumberTest.php
+++ b/tests/Validator/Constraints/PhoneNumberTest.php
@@ -30,6 +30,21 @@ class PhoneNumberTest extends TestCase
         $this->assertObjectHasProperty('type', $phoneNumber);
         $this->assertObjectHasProperty('defaultRegion', $phoneNumber);
         $this->assertObjectHasProperty('regionPath', $phoneNumber);
+        $this->assertObjectHasProperty('validation', $phoneNumber);
+    }
+
+    public function testValidationPropertyDefaultsToIsValidNumber(): void
+    {
+        $phoneNumber = new PhoneNumber();
+
+        $this->assertSame(PhoneNumber::IS_VALID_NUMBER, $phoneNumber->validation);
+    }
+
+    public function testValidationPropertyCanBeSetToIsPossibleNumber(): void
+    {
+        $phoneNumber = new PhoneNumber(validation: PhoneNumber::IS_POSSIBLE_NUMBER);
+
+        $this->assertSame(PhoneNumber::IS_POSSIBLE_NUMBER, $phoneNumber->validation);
     }
 
     /**

--- a/tests/Validator/Constraints/PhoneNumberTest.php
+++ b/tests/Validator/Constraints/PhoneNumberTest.php
@@ -30,21 +30,21 @@ class PhoneNumberTest extends TestCase
         $this->assertObjectHasProperty('type', $phoneNumber);
         $this->assertObjectHasProperty('defaultRegion', $phoneNumber);
         $this->assertObjectHasProperty('regionPath', $phoneNumber);
-        $this->assertObjectHasProperty('validation', $phoneNumber);
+        $this->assertObjectHasProperty('validationType', $phoneNumber);
     }
 
-    public function testValidationPropertyDefaultsToIsValidNumber(): void
+    public function testValidationTypePropertyDefaultsToValidNumber(): void
     {
         $phoneNumber = new PhoneNumber();
 
-        $this->assertSame(PhoneNumber::IS_VALID_NUMBER, $phoneNumber->validation);
+        $this->assertSame(PhoneNumber::VALIDATION_TYPE_VALID_NUMBER, $phoneNumber->validationType);
     }
 
-    public function testValidationPropertyCanBeSetToIsPossibleNumber(): void
+    public function testValidationTypePropertyCanBeSetToPossibleNumber(): void
     {
-        $phoneNumber = new PhoneNumber(validation: PhoneNumber::IS_POSSIBLE_NUMBER);
+        $phoneNumber = new PhoneNumber(validationType: PhoneNumber::VALIDATION_TYPE_POSSIBLE_NUMBER);
 
-        $this->assertSame(PhoneNumber::IS_POSSIBLE_NUMBER, $phoneNumber->validation);
+        $this->assertSame(PhoneNumber::VALIDATION_TYPE_POSSIBLE_NUMBER, $phoneNumber->validationType);
     }
 
     /**

--- a/tests/Validator/Constraints/PhoneNumberValidatorTest.php
+++ b/tests/Validator/Constraints/PhoneNumberValidatorTest.php
@@ -58,8 +58,9 @@ class PhoneNumberValidatorTest extends TestCase
         ?string $regionPath = null,
         PhoneNumberFormat|int|null $format = null,
         ?string $requiredRegion = null,
+        ?string $validation = null,
     ): void {
-        $constraint = new PhoneNumber($format, $type, $defaultRegion, $regionPath, requiredRegion: $requiredRegion);
+        $constraint = new PhoneNumber($format, $type, $defaultRegion, $regionPath, requiredRegion: $requiredRegion, validation: $validation);
 
         if (true === $violates) {
             $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
@@ -100,9 +101,11 @@ class PhoneNumberValidatorTest extends TestCase
 
         [$constraint1] = $classMetadata->getPropertyMetadata('phoneNumber1')[0]->getConstraints();
         [$constraint2] = $classMetadata->getPropertyMetadata('phoneNumber2')[0]->getConstraints();
+        [$constraint3] = $classMetadata->getPropertyMetadata('phoneNumber3')[0]->getConstraints();
 
         $this->validator->validate('+33606060606', $constraint1);
         $this->validator->validate('+441234567890', $constraint2);
+        $this->validator->validate('+12530000000', $constraint3);
 
         $this->expectNotToPerformAssertions();
     }
@@ -115,6 +118,7 @@ class PhoneNumberValidatorTest extends TestCase
      * 4 => Region Path (optional).
      * 5 => Format (optional)
      * 6 => Required region (optional).
+     * 7 => Validation mode (optional).
      *
      * @return iterable<array{
      *     string|LibPhoneNumber|null,
@@ -123,7 +127,8 @@ class PhoneNumberValidatorTest extends TestCase
      *     3?: ?string,
      *     4?: ?string,
      *     5?: PhoneNumberFormat|int|null,
-     *     6?: string|null
+     *     6?: string|null,
+     *     7?: string|null
      *  }>
      */
     public function validateProvider(): iterable
@@ -174,6 +179,12 @@ class PhoneNumberValidatorTest extends TestCase
         yield ['+33650505050', false, null, null, null, PhoneNumberFormat::E164, 'FR'];
         yield ['+33650505050', true, null, null, null, PhoneNumberFormat::E164, 'GB'];
 
+        // Possible but not valid (libphonenumber): passes only with IS_POSSIBLE_NUMBER
+        yield ['+12530000000', true];
+        yield ['+12530000000', false, null, null, null, null, null, PhoneNumber::IS_POSSIBLE_NUMBER];
+        yield ['+12530000000', true, null, null, null, null, null, PhoneNumber::IS_VALID_NUMBER];
+        yield ['+12530000000', true, PhoneNumber::MOBILE, null, null, null, null, PhoneNumber::IS_POSSIBLE_NUMBER];
+
         // Ensure BC promise is respected
         yield ['+33606060606', false, 'mobile', null, null, 0];
         yield ['2015555555', true, null, null, null, 0];
@@ -206,6 +217,10 @@ class PhoneNumberDummy
     #[PhoneNumber(regionPath: 'regionPath')]
     /* @phpstan-ignore-next-line */
     private PhoneNumber $phoneNumber2;
+
+    #[PhoneNumber(validation: PhoneNumber::IS_POSSIBLE_NUMBER)]
+    /* @phpstan-ignore-next-line */
+    private PhoneNumber $phoneNumber3;
 
     public string $regionPath = 'GB';
 }

--- a/tests/Validator/Constraints/PhoneNumberValidatorTest.php
+++ b/tests/Validator/Constraints/PhoneNumberValidatorTest.php
@@ -58,9 +58,9 @@ class PhoneNumberValidatorTest extends TestCase
         ?string $regionPath = null,
         PhoneNumberFormat|int|null $format = null,
         ?string $requiredRegion = null,
-        ?string $validation = null,
+        ?string $validationType = null,
     ): void {
-        $constraint = new PhoneNumber($format, $type, $defaultRegion, $regionPath, requiredRegion: $requiredRegion, validation: $validation);
+        $constraint = new PhoneNumber($format, $type, $defaultRegion, $regionPath, requiredRegion: $requiredRegion, validationType: $validationType);
 
         if (true === $violates) {
             $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
@@ -118,7 +118,7 @@ class PhoneNumberValidatorTest extends TestCase
      * 4 => Region Path (optional).
      * 5 => Format (optional)
      * 6 => Required region (optional).
-     * 7 => Validation mode (optional).
+     * 7 => validationType (optional).
      *
      * @return iterable<array{
      *     string|LibPhoneNumber|null,
@@ -179,11 +179,11 @@ class PhoneNumberValidatorTest extends TestCase
         yield ['+33650505050', false, null, null, null, PhoneNumberFormat::E164, 'FR'];
         yield ['+33650505050', true, null, null, null, PhoneNumberFormat::E164, 'GB'];
 
-        // Possible but not valid (libphonenumber): passes only with IS_POSSIBLE_NUMBER
+        // Possible but not valid (libphonenumber): passes only with VALIDATION_TYPE_POSSIBLE_NUMBER
         yield ['+12530000000', true];
-        yield ['+12530000000', false, null, null, null, null, null, PhoneNumber::IS_POSSIBLE_NUMBER];
-        yield ['+12530000000', true, null, null, null, null, null, PhoneNumber::IS_VALID_NUMBER];
-        yield ['+12530000000', true, PhoneNumber::MOBILE, null, null, null, null, PhoneNumber::IS_POSSIBLE_NUMBER];
+        yield ['+12530000000', false, null, null, null, null, null, PhoneNumber::VALIDATION_TYPE_POSSIBLE_NUMBER];
+        yield ['+12530000000', true, null, null, null, null, null, PhoneNumber::VALIDATION_TYPE_VALID_NUMBER];
+        yield ['+12530000000', true, PhoneNumber::MOBILE, null, null, null, null, PhoneNumber::VALIDATION_TYPE_POSSIBLE_NUMBER];
 
         // Ensure BC promise is respected
         yield ['+33606060606', false, 'mobile', null, null, 0];
@@ -218,7 +218,7 @@ class PhoneNumberDummy
     /* @phpstan-ignore-next-line */
     private PhoneNumber $phoneNumber2;
 
-    #[PhoneNumber(validation: PhoneNumber::IS_POSSIBLE_NUMBER)]
+    #[PhoneNumber(validationType: PhoneNumber::VALIDATION_TYPE_POSSIBLE_NUMBER)]
     /* @phpstan-ignore-next-line */
     private PhoneNumber $phoneNumber3;
 


### PR DESCRIPTION
## Summary

This PR adds an explicit `validation` option to the `PhoneNumber` constraint so callers can choose between libphonenumber’s `isValidNumber()` (existing default) and `isPossibleNumber()` for a more permissive check.

## Motivation

`isValidNumber()` ensures the number is valid for the region and typically assigned in the numbering plan. `isPossibleNumber()` only checks that the length and national format are plausible. Some applications need to accept numbers that are “possible” but not yet recognized as valid by the metadata.

## What changed

### Constraint (`PhoneNumber`)

- New constants: `PhoneNumber::IS_VALID_NUMBER` (`'isValidNumber'`), `PhoneNumber::IS_POSSIBLE_NUMBER` (`'isPossibleNumber'`)
- New property: `public string $validation = self::IS_VALID_NUMBER`
- New constructor argument: `?string $validation = null` (named arguments supported)

### Validator (`PhoneNumberValidator`)

- After a successful parse, if `validation === IS_POSSIBLE_NUMBER`, uses `PhoneNumberUtil::isPossibleNumber()`; otherwise uses `isValidNumber()` (unchanged default).
- `requiredRegion` and `type` checks run after this step; a short comment documents behavior when `getNumberType()` does not match a restricted `type`.

## Backward compatibility

Default `validation` is `IS_VALID_NUMBER` — same behavior as before for existing usages.

## Documentation

README (“Validating phone numbers”): option, attribute example, warning about permissiveness.

## Tests

Constraint defaults; validator cases for possible-but-not-valid; type + possible mode; attribute loading.

## Example

    use Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumber as AssertPhoneNumber;

    #[AssertPhoneNumber(validation: AssertPhoneNumber::IS_POSSIBLE_NUMBER)]
    private $phoneNumber;

## Files touched

- `src/Validator/Constraints/PhoneNumber.php`
- `src/Validator/Constraints/PhoneNumberValidator.php`
- `tests/Validator/Constraints/PhoneNumberTest.php`
- `tests/Validator/Constraints/PhoneNumberValidatorTest.php`
- `README.md`

## Checklist

- [ ] Tests pass locally (`./vendor/bin/phpunit`)
- [ ] Coding standards if required by the project (`make cs-lint` or equivalent)
- [ ] Static analysis if required (`make phpstan` or equivalent)

Closes #218 