### PR TITLE
Apply code style fixes and align PHPStan configuration

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,3 @@ parameters:
     paths:
       - src
       - tests
-
-    ignoreErrors:
-    - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\).#'

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('misd_phone_number');
         $rootNode = $treeBuilder->getRootNode();
 
-        $normalizer = function ($value) {
+        $normalizer = static function ($value) {
             if (\is_bool($value)) {
                 return [
                     'enabled' => $value,
@@ -68,7 +68,7 @@ class Configuration implements ConfigurationInterface
                             ->values(PhoneNumberFormat::cases())
                             ->defaultValue(PhoneNumberFormat::E164)
                             ->beforeNormalization()
-                                ->ifTrue(fn ($value) => \is_string($value) || \is_int($value))
+                                ->ifTrue(static fn ($value) => \is_string($value) || \is_int($value))
                                 ->then($normalizeFormat)
                             ->end()
                         ->end()
@@ -97,7 +97,7 @@ class Configuration implements ConfigurationInterface
                             ->values(PhoneNumberFormat::cases())
                             ->defaultValue(PhoneNumberFormat::E164)
                             ->beforeNormalization()
-                                ->ifTrue(fn ($value) => \is_string($value) || \is_int($value))
+                                ->ifTrue(static fn ($value) => \is_string($value) || \is_int($value))
                                 ->then($normalizeFormat)
                             ->end()
                         ->end()
@@ -116,7 +116,7 @@ class Configuration implements ConfigurationInterface
                             ->values(PhoneNumberFormat::cases())
                             ->defaultValue(PhoneNumberFormat::INTERNATIONAL)
                             ->beforeNormalization()
-                                ->ifTrue(fn ($value) => \is_string($value) || \is_int($value))
+                                ->ifTrue(static fn ($value) => \is_string($value) || \is_int($value))
                                 ->then($normalizeFormat)
                             ->end()
                         ->end()

--- a/src/Form/Type/PhoneNumberType.php
+++ b/src/Form/Type/PhoneNumberType.php
@@ -138,7 +138,7 @@ class PhoneNumberType extends AbstractType
     {
         $resolver->setDefaults([
             'widget' => self::WIDGET_SINGLE_TEXT,
-            'compound' => function (Options $options): bool {
+            'compound' => static function (Options $options): bool {
                 return self::WIDGET_SINGLE_TEXT !== $options['widget'];
             },
             'default_region' => PhoneNumberUtil::UNKNOWN_REGION,

--- a/src/Resources/config/form.php
+++ b/src/Resources/config/form.php
@@ -7,7 +7,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Misd\PhoneNumberBundle\Form\Extension\PhoneNumberTypeEqualityExtension;
 use Misd\PhoneNumberBundle\Form\Type\PhoneNumberType;
 
-return function (ContainerConfigurator $container): void {
+return static function (ContainerConfigurator $container): void {
     $container->services()
         ->set(PhoneNumberType::class)
             ->tag('form.type', ['alias' => 'phone_number'])

--- a/src/Resources/config/serializer.php
+++ b/src/Resources/config/serializer.php
@@ -6,7 +6,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Misd\PhoneNumberBundle\Serializer\Normalizer\PhoneNumberNormalizer;
 
-return function (ContainerConfigurator $container): void {
+return static function (ContainerConfigurator $container): void {
     $container->services()
         ->set(PhoneNumberNormalizer::class)
             ->tag('serializer.normalizer')

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -10,7 +10,7 @@ use libphonenumber\PhoneNumberToTimeZonesMapper;
 use libphonenumber\PhoneNumberUtil;
 use libphonenumber\ShortNumberInfo;
 
-return function (ContainerConfigurator $container): void {
+return static function (ContainerConfigurator $container): void {
     $container->services()
         ->set(PhoneNumberUtil::class)
             ->factory([PhoneNumberUtil::class, 'getInstance'])

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -8,7 +8,7 @@ use libphonenumber\PhoneNumberUtil;
 use Misd\PhoneNumberBundle\Templating\Helper\PhoneNumberHelper;
 use Misd\PhoneNumberBundle\Twig\Extension\PhoneNumberHelperExtension;
 
-return function (ContainerConfigurator $container): void {
+return static function (ContainerConfigurator $container): void {
     $container->services()
         ->set(PhoneNumberHelper::class)
             ->args([

--- a/src/Resources/config/validator.php
+++ b/src/Resources/config/validator.php
@@ -7,7 +7,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use libphonenumber\PhoneNumberUtil;
 use Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumberValidator;
 
-return function (ContainerConfigurator $container): void {
+return static function (ContainerConfigurator $container): void {
     $container->services()
         ->set(PhoneNumberValidator::class)
             ->tag('validator.constraint_validator')

--- a/tests/Form/Type/PhoneNumberTypeTest.php
+++ b/tests/Form/Type/PhoneNumberTypeTest.php
@@ -53,9 +53,8 @@ class PhoneNumberTypeTest extends TestCase
 
         if (method_exists($form, 'getTransformationFailure') && $failure = $form->getTransformationFailure()) {
             throw $failure;
-        } else {
-            $this->assertTrue($form->isSynchronized());
         }
+        $this->assertTrue($form->isSynchronized());
 
         $view = $form->createView();
 
@@ -103,9 +102,8 @@ class PhoneNumberTypeTest extends TestCase
 
         if (method_exists($form, 'getTransformationFailure') && $failure = $form->getTransformationFailure()) {
             throw $failure;
-        } else {
-            $this->assertTrue($form->isSynchronized());
         }
+        $this->assertTrue($form->isSynchronized());
 
         $view = $form->createView();
 


### PR DESCRIPTION
## Summary

- Ran **PHP-CS-Fixer** (`make cs-fix`): use `static` closures where appropriate (Symfony PHP config files, `Configuration`, form `compound` option) and simplified control flow in form tests.
- Removed the obsolete **`ignoreErrors`** entry from `phpstan.neon` (the pattern for `NodeDefinition::children()` no longer matched any reported errors, which caused PHPStan to fail).

## Checks

- `make cs-lint` / `make phpstan`
- `./vendor/bin/phpunit`